### PR TITLE
  1. the include file order is a bit chaos, this is work around patch

### DIFF
--- a/MatrixOps.hpp
+++ b/MatrixOps.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include "quantization_utils.hpp"
 #include "tensor.hpp"
+#include "uTensorBase.hpp"
 
 // tensorflow/tensorflow/core/kernels/reference_gemm.h
 


### PR DESCRIPTION
 1.  the include file order is a bit chaos, this is work around patch to make the include correct. We need to rearrange file hierarchy in the future.
2. just include uTensorBase to make Operator definition scope seen by MatrixOps