### PR TITLE
Feature/space savings2

### DIFF
--- a/TESTS/core/tensor/test_core_binarytensor.cpp
+++ b/TESTS/core/tensor/test_core_binarytensor.cpp
@@ -28,7 +28,7 @@ void test_core_reshapeBinaryTensor() {
     std::default_random_engine gen;
     TensorShape tmp({3, 2, 3});
     std::string a_s = "input" + to_string(i);
-    S_TENSOR inputTensor = ctx.add(new BinaryTensor<int>(tmp, val), a_s);
+    S_TENSOR inputTensor = ctx.add(new BinaryTensor<int>(tmp, val), a_s.c_str());
     vector<uint8_t> permute = {2, 1, 0};
     TensorShape g = inputTensor->getShape();
     std::shuffle(permute.begin(), permute.end(), gen);
@@ -36,7 +36,7 @@ void test_core_reshapeBinaryTensor() {
     permuteIndexTransform trans(inputTensor->getShape(), permute);
 
     std::string a_o = "output" + to_string(i);
-    S_TENSOR output = ctx.add(new BinaryTensor<int>(trans.getNewShape(), val), a_o);
+    S_TENSOR output = ctx.add(new BinaryTensor<int>(trans.getNewShape(), val), a_o.c_str());
     TensorShape s = output->getShape();
     res = testshape<uint32_t>(g, s, permute);
     if (!res) {

--- a/TESTS/core/tensor/test_core_tensor.cpp
+++ b/TESTS/core/tensor/test_core_tensor.cpp
@@ -27,7 +27,7 @@ void test_core_reshapeTensor() {
     std::default_random_engine gen;
     TensorShape tmp({2, 3, 4, 5});
     std::string a_s = "input" + std::to_string(i);
-    S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s);
+    S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s.c_str());
     vector<uint8_t> permute = {2, 3, 1, 0};
     TensorShape g = inputTensor->getShape();
     std::shuffle(permute.begin(), permute.end(), gen);
@@ -35,7 +35,7 @@ void test_core_reshapeTensor() {
     permuteIndexTransform trans(inputTensor->getShape(), permute);
 
     std::string a_o = "output" + std::to_string(i);
-    S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o);
+    S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o.c_str());
     TensorShape s = output->getShape();
     res = testshape<uint32_t>(g, s, permute);
     if (!res) {

--- a/TESTS/core/virtualmem/test_core_virtualmem.cpp
+++ b/TESTS/core/virtualmem/test_core_virtualmem.cpp
@@ -17,17 +17,17 @@ void test_core_vmload() {
         string tmp_file = "/fs/constants/sdtmp/tmp.txt";
         vm g;
         unsigned char* data_g = (unsigned char*)malloc(t->getSize_in_bytes());
-        g.createFile(tmp_file);
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data_g);
+        g.createFile(tmp_file.c_str());
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data_g);
         uint32_t res_x = 0;
         uint32_t res_y = 0;
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i];
         }
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data + 30);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data_g);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data + 30);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data_g);
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i + 30];
@@ -43,12 +43,12 @@ void test_core_vmwrite(void) {
         unsigned char* data = t->write<unsigned char>(0, 0);
         string tmp_file = "/fs/constants/sdtmp/tmp2.txt";
         vm g;
-        FILE *buf = g.createFile(tmp_file);  
+        FILE *buf = g.createFile(tmp_file.c_str());  
         uint8_t size = (uint8_t)t->unit_size();
         uint32_t totalsize = t->getSize();
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data);
         unsigned char* data_g = (unsigned char*)malloc(t->unit_size() * 30);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data_g);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data_g);
         uint32_t res_x = 0;
         uint32_t res_y = 0;
         for (unsigned int i = 0; i < 30; i++) {
@@ -56,8 +56,8 @@ void test_core_vmwrite(void) {
            res_y += data[i];
            EXPECT_EQ(res_x, res_y);
         }
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data + 30);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data_g);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data + 30);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data_g);
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i + 30];

--- a/deprecated/TESTS/tensor_test.hpp
+++ b/deprecated/TESTS/tensor_test.hpp
@@ -36,7 +36,7 @@ class transTest : public Test {
       std::default_random_engine gen;
       vector<uint32_t> tmp({2, 3, 4, 5});
       std::string a_s = "input" + std::to_string(i);
-      S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s);
+      S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s.c_str());
       vector<uint8_t> permute = {2, 3, 1, 0};
       vector<uint32_t> g = inputTensor->getShape();
       std::shuffle(permute.begin(), permute.end(), gen);
@@ -44,7 +44,7 @@ class transTest : public Test {
       permuteIndexTransform trans(inputTensor->getShape(), permute);
 
       std::string a_o = "output" + std::to_string(i);
-      S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o);
+      S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o.c_str());
       vector<uint32_t> s = output->getShape();
       res = testshape<uint32_t>(g, s, permute);
       if (!res) {

--- a/deprecated/TESTS/vmtest.hpp
+++ b/deprecated/TESTS/vmtest.hpp
@@ -14,17 +14,17 @@ class vmTest : public Test {
         string tmp_file = "/fs/tmp/tmp.txt";
         vm g;
         unsigned char* data_g = (unsigned char*)malloc(t->getSize_in_bytes());
-        g.createFile(tmp_file);
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data_g);
+        g.createFile(tmp_file.c_str());
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data_g);
         uint32_t res_x = 0;
         uint32_t res_y = 0;
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i];
         }
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data + 30);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data_g);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data + 30);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data_g);
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i + 30];
@@ -40,20 +40,20 @@ class vmTest : public Test {
         unsigned char* data = t->write<unsigned char>(0, 0);
         string tmp_file = "/fs/tmp/tmp2.txt";
         vm g;
-        FILE *buf = g.createFile(tmp_file);  
+        FILE *buf = g.createFile(tmp_file.c_str());  
         uint8_t size = (uint8_t)t->unit_size();
         uint32_t totalsize = t->getSize();
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data);
-        g.flush_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data + 30);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data);
+        g.flush_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data + 30);
         unsigned char* data_g = (unsigned char*)malloc(t->unit_size() * 30);
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 0,  data_g);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 0,  data_g);
         uint32_t res_x = 0;
         uint32_t res_y = 0;
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i];
         }
-        g.load_data<unsigned char>(tmp_file, t->unit_size(), 30, t->getSize(), 30,  data_g);
+        g.load_data<unsigned char>(tmp_file.c_str(), t->unit_size(), 30, t->getSize(), 30,  data_g);
         for (unsigned int i = 0; i < 30; i++) {
            res_x += data_g[i];
            res_y += data[i + 30];

--- a/examples/deep_mnist_mlp.cpp
+++ b/examples/deep_mnist_mlp.cpp
@@ -105,7 +105,7 @@ void PredLayer(Context &ctx, TName input, TName input_min,
   ctx.push(new ArgMaxOp<float, int>(), {"output_z_pred", dim}, {output});
 }
 
-int runMLP(string inputIdxFile) {
+int runMLP(const char* inputIdxFile) {
   TensorIdxImporter t_import;
   Context ctx;
   ctx.add(new RamTensor<unsigned char>(), "x_quantized"); 

--- a/examples/deep_mnist_mlp.hpp
+++ b/examples/deep_mnist_mlp.hpp
@@ -21,6 +21,6 @@ void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
 void PredLayer(Context &ctx, TName input, TName input_min,
                TName input_max, TName output, TName w, TName w_min, TName w_max, TName bias, TName dim);
 
-int runMLP(string inputIdxFile);
+int runMLP(const char* inputIdxFile);
 
 #endif

--- a/uTensor/core/context.cpp
+++ b/uTensor/core/context.cpp
@@ -29,7 +29,7 @@ S_TENSOR Context::addCached(std::function<void*(void)> func, TName _name, uint8_
 S_TENSOR Context::add(Tensor* t, TName _name, uint8_t init_count) {
   if(t == nullptr) { ERR_EXIT("null pointer tensor"); }
   if(rTable.find(_name) != rTable.end()) {
-    ERR_EXIT("tensor with name \"%s\" address already exist in rTable", t->getName().c_str());
+    ERR_EXIT("tensor with name \"%d\" address already exist in rTable", t->getName().get_value());
   }
 
   S_TENSOR _sptr(t);
@@ -50,7 +50,7 @@ S_TENSOR Context::add(Tensor* t, TName _name, uint8_t init_count) {
 }
 
 S_TENSOR Context::get(TName const &t_name) {
-  if(rTable.find(t_name) == rTable.end()) ERR_EXIT("No tensor with name: %s", t_name.c_str());
+  if(rTable.find(t_name) == rTable.end()) ERR_EXIT("No tensor with name: %d", t_name.get_value());
   return rTable[t_name].sptr;
 }
 
@@ -93,14 +93,14 @@ void Context::push(Operator* op, TNameList &in_names, TNameList &out_names) {
   //error checking in the Op class
   S_TList _inputs;
   for(auto in:in_names) {
-    if(rTable.find(in) == rTable.end()) { ERR_EXIT("Tensor \"%s\" not found", in.c_str()); }
+    if(rTable.find(in) == rTable.end()) { ERR_EXIT("Tensor \"%d\" not found", in.get_value()); }
     Ref_Record r = rTable[in];
     _inputs.push_back(r.sptr);
   }
 
   S_TList _outputs;
   for(auto out:out_names) {
-    if(rTable.find(out) == rTable.end()) { ERR_EXIT("Tensor \"%s\" not found", out.c_str()); }
+    if(rTable.find(out) == rTable.end()) { ERR_EXIT("Tensor \"%d\" not found", out.get_value()); }
     Ref_Record r = rTable[out];
     _outputs.push_back(r.sptr);
   }

--- a/uTensor/core/sdtensor.hpp
+++ b/uTensor/core/sdtensor.hpp
@@ -10,17 +10,16 @@
 #endif
 
 ///NT: FIXME: count overflow
-static string getTmpName(void) {
+static uint32_t getTmpName(void) {
   static uint32_t count = 0;
-  return std::to_string(count++);
+  return count++;
 }
 
 template <class T>
 class SDTensor : public Tensor {
   public:
     SDTensor( uint32_t cachesize) : Tensor() {
-        string file = tmpprefix + getTmpName();
-        _filename = file;
+        sprintf(_filename, "/fs/tmp/%d", getTmpName());
         mem.createFile(_filename);
         s->cache_size = cachesize;
         cursor = 0;
@@ -34,8 +33,7 @@ class SDTensor : public Tensor {
       }
       s->cache_size = cachesize;
       Tensor::init(v);
-      string file = tmpprefix + getTmpName();
-      _filename = file;
+      sprintf(_filename, "/fs/tmp/%d", getTmpName());
       mem.createFile(_filename);
       cursor = 0;
       dirty = false;
@@ -44,8 +42,7 @@ class SDTensor : public Tensor {
     SDTensor(const TensorShape& v, uint32_t cachesize) : Tensor() {
       s->cache_size = cachesize;
       Tensor::init(v);
-      string file = tmpprefix + getTmpName();
-      _filename = file;
+      sprintf(_filename, "/fs/tmp/%d", getTmpName());
       mem.createFile(_filename);
       cursor = 0;
       dirty = false;
@@ -121,7 +118,7 @@ class SDTensor : public Tensor {
  private:
   SDTensor(const SDTensor&);
   vm mem;
-  std::string _filename;
+  char _filename[32]; //32 characters should be enough
   bool dirty;
   uint32_t cursor;
   SDTensor& operator=(const SDTensor&);

--- a/uTensor/core/tensor.cpp
+++ b/uTensor/core/tensor.cpp
@@ -1,6 +1,6 @@
 #include "tensor.hpp"
 
-void uTensor::setName(std::string _name)
+void uTensor::setName(utensor::string _name)
 {
     if(name == "") {
         name = _name;
@@ -8,7 +8,7 @@ void uTensor::setName(std::string _name)
         ERR_EXIT("Tensor %s already has a name %s\r\n", _name.c_str(), name.c_str());
     }
 }
-const std::string& uTensor::getName() const { return name; }
+const utensor::string& uTensor::getName() const { return name; }
 uTensor::~uTensor(){}
 
 void TensorBase::initialize(const TensorShape& vec) 

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -3,7 +3,7 @@
 
 #include "uTensor/util/uTensor_util.hpp"
 #include <initializer_list>
-#include <iostream>
+#include "utensor_string.hpp"
 #include <memory>
 #include <vector>
 #include <algorithm>
@@ -21,8 +21,8 @@
 
 class Tensor;
 class TensorIdxImporter;
-typedef std::string TName;
-typedef std::string OpName;
+typedef utensor::string TName;
+typedef utensor::string OpName;
 typedef std::vector<TName> TNameList;
 typedef std::shared_ptr<Tensor> S_TENSOR;
 typedef std::vector<S_TENSOR> S_TList;
@@ -37,12 +37,12 @@ class uTensor {
 public:
  virtual void inFocus(){};
  virtual void deFocus(){};
- virtual const std::string& getName() const;
- virtual void setName(std::string _name);
+ virtual const utensor::string& getName() const;
+ virtual void setName(utensor::string _name);
 
  virtual ~uTensor() = 0;
 private:
- std::string name;
+ utensor::string name;
 
 };
 

--- a/uTensor/core/vm.cpp
+++ b/uTensor/core/vm.cpp
@@ -1,6 +1,6 @@
 #include "uTensor/core/vm.hpp"
 
-FILE* vm::createFile(std::string& filename) {
-  buffer = fopen(filename.c_str(), "w");
+FILE* vm::createFile(const char* filename) {
+  buffer = fopen(filename, "w");
   return buffer;
 }

--- a/uTensor/core/vm.hpp
+++ b/uTensor/core/vm.hpp
@@ -1,7 +1,7 @@
 #ifndef UTENSOR_VM
 #define UTENSOR_VM
 #include <vector>
-#include <iostream>
+#include "mbed.h"
 
 using namespace std;
 

--- a/uTensor/core/vm.hpp
+++ b/uTensor/core/vm.hpp
@@ -1,7 +1,9 @@
 #ifndef UTENSOR_VM
 #define UTENSOR_VM
 #include <vector>
-#include "mbed.h"
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
 
 using namespace std;
 

--- a/uTensor/core/vm.hpp
+++ b/uTensor/core/vm.hpp
@@ -9,12 +9,12 @@ class vm {
   public:
 
     template<typename T>
-    void load_data(string& filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
+    void load_data(const char* filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
 
     template<typename T>
-    void flush_data(string& filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
+    void flush_data(const char* filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
 
-    FILE* createFile(string& filename);
+    FILE* createFile(const char* filename);
 
     FILE* getFile() { return buffer; }
 
@@ -46,8 +46,8 @@ void vm::flush_impl(U* dst, uint8_t unit_size, uint32_t arrsize) {
 
 
 template<typename T>
-void vm::load_data(string& filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
-  buffer = fopen(filename.c_str(), "r");
+void vm::load_data(const char* filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
+  buffer = fopen(filename, "r");
   int size = std::min(cachesize, arrsize);
   uint32_t offset_t = (uint32_t)offset;
 
@@ -58,8 +58,8 @@ void vm::load_data(string& filename, uint8_t unit_size, uint32_t cachesize, uint
 }
 
 template<typename T>
-void vm::flush_data(string& filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
-  buffer = fopen(filename.c_str(), "w");
+void vm::flush_data(const char* filename, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
+  buffer = fopen(filename, "w");
   int size = std::min(cachesize, arrsize);
   fseek(buffer, offset * unit_size, SEEK_SET);
   flush_impl(data, unit_size, size);

--- a/uTensor/loaders/tensorIdxImporter.cpp
+++ b/uTensor/loaders/tensorIdxImporter.cpp
@@ -54,11 +54,11 @@ HeaderMeta TensorIdxImporter::parseHeader(void) {
   return header;
 }
 
-void TensorIdxImporter::parseMeta(string& filename, IDX_DTYPE idx_type) {
-  fp = fopen(filename.c_str(), "r");
+void TensorIdxImporter::parseMeta(const char* filename, IDX_DTYPE idx_type) {
+  fp = fopen(filename, "r");
 
-  DEBUG("Opening file %s ", filename.c_str());
-  if (fp == NULL) ERR_EXIT("Error opening file: %s", filename.c_str());
+  DEBUG("Opening file %s ", filename);
+  if (fp == NULL) ERR_EXIT("Error opening file: %s", filename);
 
   header = parseHeader();
 

--- a/uTensor/loaders/tensorIdxImporter.hpp
+++ b/uTensor/loaders/tensorIdxImporter.hpp
@@ -5,7 +5,6 @@
 #include "uTensor/core/tensor.hpp"
 #include "uTensor/core/sdtensor.hpp"
 #include <stdio.h>
-#include <iostream>
 #include <stdlib.h>
 #include <vector>
 #include <memory>

--- a/uTensor/loaders/tensorIdxImporter.hpp
+++ b/uTensor/loaders/tensorIdxImporter.hpp
@@ -35,57 +35,57 @@ class TensorIdxImporter {
   HeaderMeta header;
   HeaderMeta parseHeader(void);
   template <typename U>
-  Tensor* loader(string& filename, IDX_DTYPE idx_type);
+  Tensor* loader(const char* filename, IDX_DTYPE idx_type);
   template <typename U>
-  Tensor* sdloader(string& filename, IDX_DTYPE idx_type, uint32_t cachesize);
-  void parseMeta(string& filename, IDX_DTYPE idx_type);
+  Tensor* sdloader(const char* filename, IDX_DTYPE idx_type, uint32_t cachesize);
+  void parseMeta(const char* filename, IDX_DTYPE idx_type);
   template <typename U>
   void load_impl(U* dst, uint8_t unit_size, uint32_t offset, uint32_t arrsize);
   template <typename U>
   void flush_impl(U* dst, uint8_t unit_size, uint32_t arrsize);
-  void open(string filename);
+  void open(const char* filename);
   // void open(FILE *fp);
 
  public:
-  Tensor* ubyte_import(string filename) {
+  Tensor* ubyte_import(const char* filename) {
     return loader<unsigned char>(filename, IDX_DTYPE::idx_ubyte);
   }
-  Tensor* byte_import(string filename) {
+  Tensor* byte_import(const char* filename) {
     return loader<char>(filename, IDX_DTYPE::idx_byte);
   }
-  Tensor* short_import(string filename) {
+  Tensor* short_import(const char* filename) {
     return loader<short>(filename, IDX_DTYPE::idx_short);
   }
-  Tensor* int_import(string filename) {
+  Tensor* int_import(const char* filename) {
     return loader<int>(filename, IDX_DTYPE::idx_int);
   }
-  Tensor* float_import(string filename) {
+  Tensor* float_import(const char* filename) {
     return loader<float>(filename, IDX_DTYPE::idx_float);
   }
-  Tensor* sd_ubyte_import(string filename, uint32_t cachesize) {
+  Tensor* sd_ubyte_import(const char* filename, uint32_t cachesize) {
     return sdloader<unsigned char>(filename, IDX_DTYPE::idx_ubyte, cachesize);
   }
-  Tensor* sd_byte_import(string filename, uint32_t cachesize) {
+  Tensor* sd_byte_import(const char* filename, uint32_t cachesize) {
     return sdloader<char>(filename, IDX_DTYPE::idx_byte, cachesize);
   }
-  Tensor* sd_short_import(string filename, uint32_t cachesize) {
+  Tensor* sd_short_import(const char* filename, uint32_t cachesize) {
     return sdloader<short>(filename, IDX_DTYPE::idx_short, cachesize);
   }
-  Tensor* sd_int_import(string filename, uint32_t cachesize) {
+  Tensor* sd_int_import(const char* filename, uint32_t cachesize) {
     return sdloader<int>(filename, IDX_DTYPE::idx_int, cachesize);
   }
-  Tensor* sd_float_import(string filename, uint32_t cachesize) {
+  Tensor* sd_float_import(const char* filename, uint32_t cachesize) {
     return sdloader<float>(filename, IDX_DTYPE::idx_float, cachesize);
   }
   uint32_t getMagicNumber(unsigned char dtype, unsigned char dim);
   template <typename T>
-  TensorShape load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
+  std::vector<uint32_t> load_data(const char* filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
   template <typename T>
-  void flush_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
+  void flush_data(const char* filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
   uint8_t getIdxDTypeSize(IDX_DTYPE dtype);
 
   template<typename U>
-  void exportFile(string& filename, IDX_DTYPE idx_type, SDTensor<U>* t, uint8_t unit_size, uint32_t arrsize);
+  void exportFile(const char* filename, IDX_DTYPE idx_type, SDTensor<U>* t, uint8_t unit_size, uint32_t arrsize);
   ~TensorIdxImporter() {
   }
   TensorIdxImporter() {
@@ -101,7 +101,7 @@ class TensorIdxImporter {
 
 
 template<typename U>
-void TensorIdxImporter::exportFile(string& filename, IDX_DTYPE idx_type, SDTensor<U>* t, uint8_t unit_size, uint32_t arrsize) {
+void TensorIdxImporter::exportFile(const char* filename, IDX_DTYPE idx_type, SDTensor<U>* t, uint8_t unit_size, uint32_t arrsize) {
   vm mem = t->getVM();
   FILE* buffer = mem.getFile();
   U* val = (U*)malloc(unit_size);
@@ -182,7 +182,7 @@ void TensorIdxImporter::flush_impl(U* res, uint8_t unit_size, uint32_t arrsize) 
   free(dst);
 }
 template <typename U>
-Tensor* TensorIdxImporter::loader(string& filename, IDX_DTYPE idx_type) {
+Tensor* TensorIdxImporter::loader(const char* filename, IDX_DTYPE idx_type) {
 
   parseMeta(filename, idx_type);
   fseek(fp, header.dataPos, SEEK_SET);
@@ -199,7 +199,7 @@ Tensor* TensorIdxImporter::loader(string& filename, IDX_DTYPE idx_type) {
 }
 
 template <typename U>
-Tensor* TensorIdxImporter::sdloader(string& filename, IDX_DTYPE idx_type, uint32_t cachesize) {
+Tensor* TensorIdxImporter::sdloader(const char* filename, IDX_DTYPE idx_type, uint32_t cachesize) {
 
   parseMeta(filename, idx_type);
   fseek(fp, header.dataPos, SEEK_SET);
@@ -214,7 +214,7 @@ Tensor* TensorIdxImporter::sdloader(string& filename, IDX_DTYPE idx_type, uint32
 }
 
 template<typename T>
-TensorShape TensorIdxImporter::load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
+std::vector<uint32_t> TensorIdxImporter::load_data(const char* filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
   parseMeta(filename, idx_type);
   if (arrsize == 0) {
     for (auto i : header.dim) {
@@ -236,7 +236,7 @@ TensorShape TensorIdxImporter::load_data(string& filename, IDX_DTYPE idx_type, u
   return header.dim;
 }
 template<typename T>
-void TensorIdxImporter::flush_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
+void TensorIdxImporter::flush_data(const char* filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
   parseMeta(filename, idx_type);
   int size = std::min(cachesize, arrsize);
   fseek(fp, header.dataPos + offset * unit_size, SEEK_SET);

--- a/uTensor/util/uTensor_util.hpp
+++ b/uTensor/util/uTensor_util.hpp
@@ -3,9 +3,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <vector>
-#include <iostream>
-
-using namespace std;
+#include "mbed.h"
 
 // #define MAX(A, B) ((A > B)? A:B)
 

--- a/uTensor/util/uTensor_util.hpp
+++ b/uTensor/util/uTensor_util.hpp
@@ -3,7 +3,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <vector>
-#include "mbed.h"
 
 // #define MAX(A, B) ((A > B)? A:B)
 

--- a/uTensor/util/utensor_string.hpp
+++ b/uTensor/util/utensor_string.hpp
@@ -4,6 +4,7 @@ namespace utensor {
     class string{
         private:
             uint32_t value;
+            const char* cstr = NULL;
 
             uint32_t hash(const char* c){
                 int v = 7;
@@ -18,6 +19,7 @@ namespace utensor {
         public:
             string(const char* that){
                 value = hash(that);
+                cstr = that;
             }
             string(){
                 value = hash("");
@@ -28,6 +30,7 @@ namespace utensor {
             bool operator == (const string& that) const { return this->value == that.value; }
 
             uint32_t get_value() const { return value; }
+            const char* c_str() const { return cstr; }
     };
 
 }

--- a/utensor_string.hpp
+++ b/utensor_string.hpp
@@ -1,0 +1,46 @@
+#include <string.h>
+
+namespace utensor {
+    class string{
+        private:
+            uint32_t value;
+
+            uint32_t hash(const char* c){
+                int v = 7;
+                for(int i = 0; i < strlen(c); i++){
+                    v = v*31 + c[i];
+                    
+                }
+
+                return v;
+            }
+
+        public:
+            string(const char* that){
+                value = hash(that);
+            }
+            string(){
+                value = hash("");
+            }
+            // bool operator < (const string& that){ return this->value < that.value; }
+            // bool operator == (const string& that){ return this->value == that.value; }
+            bool operator < (const string& that) const { return this->value < that.value; }
+            bool operator == (const string& that) const { return this->value == that.value; }
+
+            uint32_t get_value() const { return value; }
+    };
+
+}
+
+namespace std {
+    template<> struct hash<utensor::string>
+    {
+        typedef utensor::string argument_type;
+        typedef std::size_t result_type;
+
+        result_type operator()(argument_type const& s) const noexcept
+        {
+            return s.get_value();
+        }
+    };
+}


### PR DESCRIPTION
* Shrink Static RAM from 19k to 12k
* Shrink Flash from 360k to 120k

Basic idea is to remove all `std::string`s and `iostream` garbage from the codebase and replace it with `utensor::string` and c style string processing. `utensor::string` maintains a stable hash of `const char*` using the java string hash. 