### PR TITLE
F/cmsis ops

### DIFF
--- a/external/.mbedignore
+++ b/external/.mbedignore
@@ -1,0 +1,16 @@
+CMSIS_5/CMSIS/*/Examples
+CMSIS_5/CMSIS/*/Tests
+CMSIS_5/CMSIS/*/*/Examples
+CMSIS_5/CMSIS/*/Template/
+CMSIS_5/CMSIS/CoreValidation/*
+CMSIS_5/CMSIS/NN/NN_Lib_Tests/*
+CMSIS_5/CMSIS/Core_A/*
+CMSIS_5/CMSIS/DSP/DSP_Lib_TestSuite/*
+CMSIS_5/CMSIS/DoxyGen/*
+CMSIS_5/Device/_Template*
+CMSIS_5/CMSIS/RTOS2/*
+CMSIS_5/CMSIS/RTOS/*
+CMSIS_5/CMSIS/Driver/*
+CMSIS_5/Device/*
+CMSIS_5/CMSIS/DAP/*
+CMSIS_5/CMSIS/Pack/*

--- a/external/CMSIS_5.lib
+++ b/external/CMSIS_5.lib
@@ -1,0 +1,1 @@
+https://github.com/ARM-software/CMSIS_5.git

--- a/uTensor/ops/cmsis_ops/CmsisConvolution.hpp
+++ b/uTensor/ops/cmsis_ops/CmsisConvolution.hpp
@@ -1,0 +1,186 @@
+#ifndef UTENSOR_CMSIS_CONVOLUTION_HPP__
+#define UTENSOR_CMSIS_CONVOLUTION_HPP__
+#include "uTensor/core/tensor.hpp"
+#include "uTensor/core/uTensorBase.hpp"
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+
+/***
+ * Here we have two types of kernel functions. The basic function implements the function using regular GEMV approach. The opt functions operates with weights in interleaved formats.
+ *
+ * http://www.keil.com/pack/doc/CMSIS/NN/html/group__FC.html#gae3857bb6375692e81dde8cbd70adec08
+ */
+
+struct CmsisConvolveBasic {
+    void operator()(const q15_t *Im_in, const uint16_t dim_im_in, const uint16_t ch_im_in, 
+            const q15_t *wt, const uint16_t ch_im_out, const uint16_t dim_kernel, 
+            const uint16_t padding, const uint16_t stride, const q15_t *bias, 
+            const uint16_t bias_shift, const uint16_t out_shift, q15_t *Im_out, 
+            const uint16_t dim_im_out, q15_t *bufferA, q7_t *bufferB){
+        arm_convolve_HWC_q15_basic(Im_in,
+                dim_im_in,
+                ch_im_in,
+                wt,
+                ch_im_out,
+                dim_kernel,
+                padding,
+                stride,
+                bias,
+                bias_shift,
+                out_shift,
+                Im_out,
+                dim_im_out,
+                bufferA,
+                bufferB);
+
+    }
+    void operator()(const q7_t *Im_in, const uint16_t dim_im_in, const uint16_t ch_im_in, 
+            const q7_t *wt, const uint16_t ch_im_out, const uint16_t dim_kernel, 
+            const uint16_t padding, const uint16_t stride, const q7_t *bias, 
+            const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, 
+            const uint16_t dim_im_out, q15_t *bufferA, q7_t *bufferB){
+        arm_convolve_HWC_q7_basic(Im_in,
+                dim_im_in,
+                ch_im_in,
+                wt,
+                ch_im_out,
+                dim_kernel,
+                padding,
+                stride,
+                bias,
+                bias_shift,
+                out_shift,
+                Im_out,
+                dim_im_out,
+                bufferA,
+                bufferB);
+
+    }
+
+};
+
+struct CmsisConvolveFast {
+    void operator()(const q15_t *Im_in, const uint16_t dim_im_in, const uint16_t ch_im_in, 
+            const q15_t *wt, const uint16_t ch_im_out, const uint16_t dim_kernel, 
+            const uint16_t padding, const uint16_t stride, const q15_t *bias, 
+            const uint16_t bias_shift, const uint16_t out_shift, q15_t *Im_out, 
+            const uint16_t dim_im_out, q15_t *bufferA, q7_t *bufferB){
+        arm_convolve_HWC_q15_fast(Im_in,
+                dim_im_in,
+                ch_im_in,
+                wt,
+                ch_im_out,
+                dim_kernel,
+                padding,
+                stride,
+                bias,
+                bias_shift,
+                out_shift,
+                Im_out,
+                dim_im_out,
+                bufferA,
+                bufferB);
+
+    }
+    void operator()(const q7_t *Im_in, const uint16_t dim_im_in, const uint16_t ch_im_in, 
+            const q7_t *wt, const uint16_t ch_im_out, const uint16_t dim_kernel, 
+            const uint16_t padding, const uint16_t stride, const q7_t *bias, 
+            const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, 
+            const uint16_t dim_im_out, q15_t *bufferA, q7_t *bufferB){
+        arm_convolve_HWC_q7_fast(Im_in,
+                dim_im_in,
+                ch_im_in,
+                wt,
+                ch_im_out,
+                dim_kernel,
+                padding,
+                stride,
+                bias,
+                bias_shift,
+                out_shift,
+                Im_out,
+                dim_im_out,
+                bufferA,
+                bufferB);
+
+    }
+
+};
+
+struct CmsisConvolveRGB {
+    void operator()(const q7_t *Im_in, const uint16_t dim_im_in, const uint16_t ch_im_in, 
+            const q7_t *wt, const uint16_t ch_im_out, const uint16_t dim_kernel, 
+            const uint16_t padding, const uint16_t stride, const q7_t *bias, 
+            const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, 
+            const uint16_t dim_im_out, q15_t *bufferA, q7_t *bufferB){
+        arm_convolve_HWC_q7_rgb(Im_in,
+                dim_im_in,
+                ch_im_in,
+                wt,
+                ch_im_out,
+                dim_kernel,
+                padding,
+                stride,
+                bias,
+                bias_shift,
+                out_shift,
+                Im_out,
+                dim_im_out,
+                bufferA,
+                bufferB);
+
+    }
+
+};
+
+
+template<typename T, typename OP_SELECTOR>
+void CmsisConvolution(S_TENSOR im_in_s, S_TENSOR wt_s, S_TENSOR padding_s,
+                         S_TENSOR stride_s, S_TENSOR bias_s,
+                         S_TENSOR bias_shift_s, S_TENSOR out_shift_s,
+                         S_TENSOR im_out_s, S_TENSOR bufferA_s,
+                         S_TENSOR bufferB_s, T byteme1, const OP_SELECTOR& op)
+{
+    const T* im_in  = im_in_s->read<T>(0, sizeof(T)); //Read one byte
+    const T* wt = wt_s->read<T>(0, sizeof(T));
+    const T* bias = bias_s->read<T>(0, sizeof(T));
+    const uint16_t dim_im_in = im_in_s->getShape()[0];
+    const uint16_t dim_im_out = im_out_s->getShape()[0];
+    const uint16_t dim_kernel = wt_s->getShape()[0];
+    const uint16_t ch_im_in = im_in_s->getShape()[2];
+    const uint16_t ch_im_out = im_out_s->getShape()[2];
+    const uint16_t padding = *(padding_s->read<uint16_t>(0,0));
+    const uint16_t stride = *(stride_s->read<uint16_t>(0,0));
+    const uint16_t bias_shift = *(bias_shift_s->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(out_shift_s->read<uint16_t>(0,0));
+    
+    T* im_out = im_out_s->write<T>(0, sizeof(T));
+    q15_t* bufferA = bufferA_s->write<q15_t>(0, sizeof(q15_t));
+    q7_t* bufferB = bufferB_s->write<q7_t>(0, sizeof(q15_t));
+
+    op(im_in, dim_im_in, ch_im_in, wt, ch_im_out, dim_kernel,
+       padding, stride, bias, bias_shift, out_shift, im_out, dim_im_out,
+       bufferA, bufferB);
+    //Error checking
+}
+
+// Default to cmsis basic convolve as these are guaranteed to work
+template <class T, class TARGET_OP=CmsisConvolveBasic>
+class ConvolutionCmsisOp : public Operator {
+  public:
+  FullyConnectedLayerCmsisOp() {
+    n_inputs = 7;
+    n_outputs = 3;
+  }
+  virtual void compute() override {
+    T x;
+    TARGET_OP op;
+    TARGET_OP()(inputs[0], inputs[1], inputs[2], 
+        inputs[3], inputs[4], 
+        inputs[5], inputs[6],
+        outputs[0], outputs[1], outputs[2], x, op);
+  }
+};
+
+
+#endif /*UTENSOR_CMSIS_CONVOLUTION_HPP__*/

--- a/uTensor/ops/cmsis_ops/CmsisPoolingOps.hpp
+++ b/uTensor/ops/cmsis_ops/CmsisPoolingOps.hpp
@@ -1,0 +1,96 @@
+#ifndef UTENSOR_CMSIS_POOLING_FUNCTIONS
+#define UTENSOR_CMSIS_POOLING_FUNCTIONS
+#include "uTensor/core/tensor.hpp"
+#include "uTensor/core/uTensorBase.hpp"
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+
+
+void cmsis_maxpool(S_TENSOR im_in_s, S_TENSOR dim_kernel_s, S_TENSOR padding_s, S_TENSOR stride,
+        S_TENSOR bufferA_s, S_TENSOR im_out_s)
+
+        q7_t *Im_in = im_in_s->write(0, sizeof(q7_t));
+        const uint16_t dim_im_in = im_in_s->getShape()[0];
+        const uint16_t ch_im_in = im_in_s->getShape()[2];
+        *(bShift->read<uint16_t>(0,0));
+        const uint16_t dim_kernel = *(dim_kernel_s->read<uint16_t>(0, 0));
+        const uint16_t padding = *(padding_s->read<uint16_t>(0, 0))
+        const uint16_t stride = *(padding_s->read<uint16_t>(0, 0))
+        const uint16_t dim_im_out = im_out_s->getShape()[0];
+        q7_t *bufferA = bufferA_s->write(0, sizeof(q7_t));
+        q7_t *Im_out  = im_out_s->write(0, sizeof(q7_t));
+
+    arm_maxpool_q7_HWC(
+        Im_in, 
+        dim_im_in,
+        ch_im_in,
+        dim_kernel,
+        padding,
+        stride,
+        dim_im_out,
+        bufferA,
+        Im_out)
+}
+
+void cmsis_avepool(S_TENSOR im_in_s, S_TENSOR dim_kernel_s, S_TENSOR padding_s, S_TENSOR stride,
+        S_TENSOR bufferA_s, S_TENSOR im_out_s)
+
+        q7_t *Im_in = im_in_s->write(0, sizeof(q7_t));
+        const uint16_t dim_im_in = im_in_s->getShape()[0];
+        const uint16_t ch_im_in = im_in_s->getShape()[2];
+        *(bShift->read<uint16_t>(0,0));
+        const uint16_t dim_kernel = *(dim_kernel_s->read<uint16_t>(0, 0));
+        const uint16_t padding = *(padding_s->read<uint16_t>(0, 0))
+        const uint16_t stride = *(padding_s->read<uint16_t>(0, 0))
+        const uint16_t dim_im_out = im_out_s->getShape()[0];
+        q7_t *bufferA = bufferA_s->write(0, sizeof(q7_t));
+        q7_t *Im_out  = im_out_s->write(0, sizeof(q7_t));
+
+    arm_avepool_q7_HWC(
+        Im_in, 
+        dim_im_in,
+        ch_im_in,
+        dim_kernel,
+        padding,
+        stride,
+        dim_im_out,
+        bufferA,
+        Im_out)
+}
+
+template <class T=q7_t>
+class MaxPoolCmsisOp : public Operator {
+  public:
+  MaxPoolCmsisOp() {
+    n_inputs = 4;
+    n_outputs = 2;
+  }
+  virtual void compute() override {
+      cmsis_maxpool(inputs[0], 
+              inputs[1],
+              inputs[2],
+              inputs[3],
+              inputs[4],
+              outputs[0], outputs[1]);
+  }
+};
+
+template <class T=q7_t>
+class AvePoolCmsisOp : public Operator {
+  public:
+  AvePoolCmsisOp() {
+    n_inputs = 4;
+    n_outputs = 2;
+  }
+  virtual void compute() override {
+      cmsis_avepool(inputs[0], 
+              inputs[1],
+              inputs[2],
+              inputs[3],
+              inputs[4],
+              outputs[0], outputs[1]);
+  }
+};
+
+
+#endif 

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -80,29 +80,31 @@ void cmsis_fc_selector_opt<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, c
  * @param [in] scratch scrath computation space
  * @param [out] pOut output
  */
-template<typename T1, typename T2, typename T3>
-void FullyConnectedLayerCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
-                         S_TENSOR bShift, S_TENSOR oShift,
-                         S_TENSOR pOut, S_TENSOR scratch,
-                         T1 byteme1, T2 byteme2, T3 byteme3)
-{
-    const T1* iV_data  = iV->read<T1>(0, sizeof(T1)); //Read one byte
-    const T2* mW_data  = mW->read<T2>(0, sizeof(T2)); //Read one byte
-    const T3* bias_data = b->read<T3>(0, sizeof(T3)); //Read one byte
-    const uint16_t dim_vec = iV->getShape()[0];
-    const uint16_t num_of_rows = mW->getShape()[0];
-    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
-    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
-    pOut->resize(b->getShape());
-    T1* pOut_data = pOut->write<T1>(0, sizeof(T1));
-    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
-
-    cmsis_fc_selector(iV_data, mW_data, dim_vec, num_of_rows, 
-            bias_shift, out_shift, bias_data, pOut_data, scratch_data);
+struct FullyConnectedLayerCmsis {
+    template<typename T1, typename T2, typename T3>
+    void operator() (S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                             S_TENSOR bShift, S_TENSOR oShift,
+                             S_TENSOR pOut, S_TENSOR scratch,
+                             T1 byteme1, T2 byteme2, T3 byteme3)
+    {
+        const T1* iV_data  = iV->read<T1>(0, sizeof(T1)); //Read one byte
+        const T2* mW_data  = mW->read<T2>(0, sizeof(T2)); //Read one byte
+        const T3* bias_data = b->read<T3>(0, sizeof(T3)); //Read one byte
+        const uint16_t dim_vec = iV->getShape()[0];
+        const uint16_t num_of_rows = mW->getShape()[0];
+        const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+        const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+        pOut->resize(b->getShape());
+        T1* pOut_data = pOut->write<T1>(0, sizeof(T1));
+        q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
     
-
-    //Error checking
-}
+        cmsis_fc_selector(iV_data, mW_data, dim_vec, num_of_rows, 
+                bias_shift, out_shift, bias_data, pOut_data, scratch_data);
+        
+    
+        //Error checking
+    }
+};
 
 /***
  * Here we have two types of kernel functions. The basic function implements the function using regular GEMV approach. The opt functions operates with weights in interleaved formats.
@@ -117,31 +119,34 @@ void FullyConnectedLayerCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
  * @param [in] scratch scrath computation space
  * @param [out] pOut output
  */
-template<typename T1, typename T2, typename T3>
-void FullyConnectedLayerOptCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
-                         S_TENSOR bShift, S_TENSOR oShift,
-                         S_TENSOR pOut, S_TENSOR scratch,
-                         T1 byteme1, T2 byteme2, T3 byteme3)
-{
-    const T1* iV_data  = iV->read<T1>(0, sizeof(T1)); //Read one byte
-    const T2* mW_data  = mW->read<T2>(0, sizeof(T2)); //Read one byte
-    const T3* bias_data = b->read<T3>(0, sizeof(T3)); //Read one byte
-    const uint16_t dim_vec = iV->getShape()[0];
-    const uint16_t num_of_rows = mW->getShape()[0];
-    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
-    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
-    pOut->resize(b->getShape());
-    T1* pOut_data = pOut->write<T1>(0, sizeof(T1));
-    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
-
-    cmsis_fc_selector_opt(iV_data, mW_data, dim_vec, num_of_rows, 
-            bias_shift, out_shift, bias_data, pOut_data, scratch_data);
+struct FullyConnectedLayerOptCmsis{
+    template<typename T1, typename T2, typename T3>
+    void operator() (S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                             S_TENSOR bShift, S_TENSOR oShift,
+                             S_TENSOR pOut, S_TENSOR scratch,
+                             T1 byteme1, T2 byteme2, T3 byteme3)
+    {
+        const T1* iV_data  = iV->read<T1>(0, sizeof(T1)); //Read one byte
+        const T2* mW_data  = mW->read<T2>(0, sizeof(T2)); //Read one byte
+        const T3* bias_data = b->read<T3>(0, sizeof(T3)); //Read one byte
+        const uint16_t dim_vec = iV->getShape()[0];
+        const uint16_t num_of_rows = mW->getShape()[0];
+        const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+        const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+        pOut->resize(b->getShape());
+        T1* pOut_data = pOut->write<T1>(0, sizeof(T1));
+        q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
     
+        cmsis_fc_selector_opt(iV_data, mW_data, dim_vec, num_of_rows, 
+                bias_shift, out_shift, bias_data, pOut_data, scratch_data);
+        
+    
+        //Error checking
+    }
+};
 
-    //Error checking
-}
-
-template <class T1, class T2, class T3>
+//TARGET_OP={FullyConnectedLayerCmsis, FullyConnectedLayerOptCmsis}
+template <class T1, class T2, class T3, class TARGET_OP=FullyConnectedLayerCmsis>
 class FullyConnectedLayerCmsisOp : public Operator {
   public:
   FullyConnectedLayerCmsisOp() {
@@ -152,24 +157,7 @@ class FullyConnectedLayerCmsisOp : public Operator {
     T1 x;
     T2 y;
     T3 byteme;
-    FullyConnectedLayerCmsis(inputs[0], inputs[1], inputs[2], inputs[3],
-      inputs[4], outputs[0], inputs[5], x, y, byteme);
-  }
-};
-
-
-template <class T1, class T2, class T3>
-class FullyConnectedLayerOptCmsisOp : public Operator {
-  public:
-  FullyConnectedLayerOptCmsisOp() {
-    n_inputs = 6;
-    n_outputs = 1;
-  }
-  virtual void compute() override {
-    T1 x;
-    T2 y;
-    T3 byteme;
-    FullyConnectedLayerOptCmsis(inputs[0], inputs[1], inputs[2], inputs[3],
+    TARGET_OP()(inputs[0], inputs[1], inputs[2], inputs[3],
       inputs[4], outputs[0], inputs[5], x, y, byteme);
   }
 };

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -21,7 +21,8 @@
 template<typename T1, typename T2, typename TOut>
 void FullyConnectedLayerCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                          S_TENSOR bShift, S_TENSOR oShift,
-                         S_TENSOR pOut, S_TENSOR scratch)
+                         S_TENSOR pOut, S_TENSOR scratch,
+                         T1 byteme1, T2 byteme2, TOut byteme3)
 {
     //Throw error if this gets called
 }
@@ -29,7 +30,8 @@ void FullyConnectedLayerCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
 template<>
 void FullyConnectedLayerCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                         q7_t byteme1, q7_t byteme2, q7_t byteme3)
 {
     const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -51,7 +53,8 @@ void FullyConnectedLayerCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENS
 template<>
 void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                         q15_t byteme1, q15_t byteme2, q15_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
@@ -72,7 +75,8 @@ void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_T
 template<>
 void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                         q15_t byteme1, q7_t byteme2, q15_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -106,7 +110,8 @@ void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TE
 template<typename T1, typename T2, typename TOut>
 void FullyConnectedLayerOptCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                          S_TENSOR bShift, S_TENSOR oShift,
-                         S_TENSOR pOut, S_TENSOR scratch)
+                         S_TENSOR pOut, S_TENSOR scratch,
+                         q15_t byteme1, q7_t byteme2, q15_t byteme3)
 {
     //Throw error if this gets called
 }
@@ -114,7 +119,8 @@ void FullyConnectedLayerOptCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
 template<>
 void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
 {
     const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -134,7 +140,8 @@ void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_T
 template<>
 void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
@@ -155,7 +162,8 @@ void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, 
 template<>
 void FullyConnectedLayerOptCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
-                                           S_TENSOR pOut, S_TENSOR scratch)
+                                           S_TENSOR pOut, S_TENSOR scratch,
+                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -178,12 +186,15 @@ template <class T1, class T2, class TOut>
 class FullyConnectedLayerCmsisOp : public Operator {
   public:
   FullyConnectedLayerCmsisOp() {
-    n_inputs = 7;
+    n_inputs = 6;
     n_outputs = 1;
   }
   virtual void compute() override {
-    FullyConnectedLayerCmsis<T1, T2, TOut>(inputs[0], inputs[1], inputs[2], inputs[3],
-      inputs[4], inputs[5], outputs[0], inputs[6]);
+    T1 x;
+    T2 y;
+    TOut byteme;
+    FullyConnectedLayerCmsis(inputs[0], inputs[1], inputs[2], inputs[3],
+      inputs[4], outputs[0], inputs[5], x, y, byteme);
   }
 };
 
@@ -193,11 +204,14 @@ class FullyConnectedLayerOptCmsisOp : public Operator {
   public:
   FullyConnectedLayerOptCmsisOp() {
     n_inputs = 6;
-    n_outputs = 3;
+    n_outputs = 1;
   }
   virtual void compute() override {
+    T1 x;
+    T2 y;
+    TOut byteme;
     FullyConnectedLayerOptCmsis<T1, T2, TOut>(inputs[0], inputs[1], inputs[2], inputs[3],
-      inputs[4], inputs[5], outputs[0], inputs[6]);
+      inputs[4], outputs[0], inputs[5], x, y, byteme);
   }
 };
 

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -1,0 +1,153 @@
+#ifndef UTENSOR_FULLY_CONNECTED_OPS
+#define UTENSOR_FULLY_CONNECTED_OPS
+#include "uTensor/core/tensor.hpp"
+#include "uTensor/core/uTensorBase.hpp"
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+
+/***
+ * Here we have two types of kernel functions. The basic function implements the function using regular GEMV approach. The opt functions operates with weights in interleaved formats.
+ *
+ * http://www.keil.com/pack/doc/CMSIS/NN/html/group__FC.html#gae3857bb6375692e81dde8cbd70adec08
+ */
+
+/**
+ * @param [in] iV input vector
+ * @param [in] mW matrix weights
+ * @param [in] b bias
+ * @param [in] scratch scrath computation space
+ * @param [out] pOut output
+ */
+template<typename T1, typename T2, typename TOut>
+void FullyConnectedLayerCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                         S_TENSOR bShift, S_TENSOR oShift,
+                         S_TENSOR pOut, S_TENSOR scratch)
+{
+    //Throw error if this gets called
+}
+
+template<>
+void FullyConnectedLayerCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_q7(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+template<>
+void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_q15(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+
+/***
+ * Here we have two types of kernel functions. The basic function implements the function using regular GEMV approach. The opt functions operates with weights in interleaved formats.
+ *
+ * http://www.keil.com/pack/doc/CMSIS/NN/html/group__FC.html#gae3857bb6375692e81dde8cbd70adec08
+ */
+
+/**
+ * @param [in] iV input vector
+ * @param [in] mW matrix weights
+ * @param [in] b bias
+ * @param [in] scratch scrath computation space
+ * @param [out] pOut output
+ */
+template<typename T1, typename T2, typename TOut>
+void FullyConnectedLayerOptCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                         S_TENSOR bShift, S_TENSOR oShift,
+                         S_TENSOR pOut, S_TENSOR scratch)
+{
+    //Throw error if this gets called
+}
+
+template<>
+void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_q7_opt(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+template<>
+void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_q15_opt(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+
+
+template <class T1, class T2, class TOut>
+class FullyConnectedLayerCmsisOp : public Operator {
+  public:
+  FullyConnectedLayerCmsisOp() {
+    n_inputs = 7;
+    n_outputs = 1;
+  }
+  virtual void compute() override {
+    FullyConnectedLayerCmsis<T1, T2, TOut>(inputs[0], inputs[1], inputs[2], inputs[3],
+      inputs[4], inputs[5], outputs[0], inputs[6]);
+  }
+};
+
+
+template <class T1, class T2, class TOut>
+class FullyConnectedLayerOptCmsisOp : public Operator {
+  public:
+  FullyConnectedLayerOptCmsisOp() {
+    n_inputs = 6;
+    n_outputs = 3;
+  }
+  virtual void compute() override {
+    FullyConnectedLayerOptCmsis<T1, T2, TOut>(inputs[0], inputs[1], inputs[2], inputs[3],
+      inputs[4], inputs[5], outputs[0], inputs[6]);
+  }
+};
+
+
+#endif /*UTENSOR_FULLY_CONNECTED_OPS*/

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -18,7 +18,8 @@ void cmsis_fc_selector(const T1* iV, const T2* mW, const uint16_t dim_vec, const
 template<>
 void cmsis_fc_selector<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
-                       q7_t* pOut, q15_t* scratch_data){
+                       q7_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_q7(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
@@ -26,7 +27,8 @@ void cmsis_fc_selector<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const u
 template<>
 void cmsis_fc_selector<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q15_t* bias, 
-                       q15_t* pOut, q15_t* scratch_data){
+                       q15_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_q15(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
@@ -34,7 +36,8 @@ void cmsis_fc_selector<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, co
 template<>
 void cmsis_fc_selector<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
-                       q15_t* pOut, q15_t* scratch_data){
+                       q15_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_mat_q7_vec_q15(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
@@ -46,7 +49,8 @@ void cmsis_fc_selector_opt(const T1* iV, const T2* mW, const uint16_t dim_vec, c
 template<>
 void cmsis_fc_selector_opt<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
-                       q7_t* pOut, q15_t* scratch_data){
+                       q7_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_q7_opt(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
@@ -54,7 +58,8 @@ void cmsis_fc_selector_opt<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, con
 template<>
 void cmsis_fc_selector_opt<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q15_t* bias, 
-                       q15_t* pOut, q15_t* scratch_data){
+                       q15_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_q15_opt(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
@@ -62,7 +67,8 @@ void cmsis_fc_selector_opt<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW
 template<>
 void cmsis_fc_selector_opt<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
-                       q15_t* pOut, q15_t* scratch_data){
+                       q15_t* pOut, q15_t* scratch_data)
+{
     arm_fully_connected_mat_q7_vec_q15_opt(iV, mW, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias, pOut, scratch_data);
 }

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -39,8 +39,8 @@ void FullyConnectedLayerCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENS
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q7_t* pOut_data = pOut->write<q7_t>(0, sizeof(q7_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_q7(iV_data, mW_data, dim_vec, num_of_rows, 
             bias_shift, out_shift, bias_data, pOut_data, scratch_data);
@@ -61,8 +61,8 @@ void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_T
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q15_t* pOut_data = pOut->write<q15_t>(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_q15(iV_data, mW_data, dim_vec, num_of_rows, 
                         bias_shift, out_shift, bias_data, pOut_data, scratch_data);
@@ -75,15 +75,15 @@ void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TE
                                            S_TENSOR pOut, S_TENSOR scratch)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
-    const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q15_t* pOut_data = pOut->write<q15_t>(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_mat_q7_vec_q15(iV_data, mW_data, dim_vec, num_of_rows, 
                         bias_shift, out_shift, bias_data, pOut_data, scratch_data);
@@ -124,8 +124,8 @@ void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_T
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q7_t* pOut_data = pOut->write<q7_t>(0, sizeof(q7_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_q7_opt(iV_data, mW_data, dim_vec, num_of_rows, 
                         bias_shift, out_shift, bias_data, pOut_data, scratch_data);
@@ -144,8 +144,8 @@ void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, 
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q15_t* pOut_data = pOut->write<q15_t>(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_q15_opt(iV_data, mW_data, dim_vec, num_of_rows, 
                         bias_shift, out_shift, bias_data, pOut_data, scratch_data);
@@ -158,15 +158,15 @@ void FullyConnectedLayerOptCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S
                                            S_TENSOR pOut, S_TENSOR scratch)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
-    const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
     pOut->resize(b->getShape());
-    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
-    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+    q15_t* pOut_data = pOut->write<q15_t>(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write<q15_t>(0, sizeof(q15_t));
 
     arm_fully_connected_mat_q7_vec_q15_opt(iV_data, mW_data, dim_vec, num_of_rows, 
                         bias_shift, out_shift, bias_data, pOut_data, scratch_data);

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -63,6 +63,25 @@ void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_T
     //Error checking
 }
 
+template<>
+void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_mat_q7_vec_q15(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+
 /***
  * Here we have two types of kernel functions. The basic function implements the function using regular GEMV approach. The opt functions operates with weights in interleaved formats.
  *
@@ -117,6 +136,25 @@ void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, 
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
     arm_fully_connected_q15_opt(iV_data, mW_data, dim_vec, dim_vec, 
+            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    //Error checking
+}
+
+template<>
+void FullyConnectedLayerOptCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+                                           S_TENSOR bShift, S_TENSOR oShift,
+                                           S_TENSOR pOut, S_TENSOR scratch)
+{
+    const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const uint16_t dim_vec = iV->getShape()[0];
+    const uint16_t num_of_rows = mW->getShape()[0];
+    const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
+    const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
+    q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
+
+    arm_fully_connected_mat_q7_vec_q15_opt(iV_data, mW_data, dim_vec, dim_vec, 
             num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
     //Error checking
 }

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -73,10 +73,10 @@ void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_T
 }
 
 template<>
-void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+void FullyConnectedLayerCmsis<q15_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
                                            S_TENSOR pOut, S_TENSOR scratch,
-                         q15_t byteme1, q7_t byteme2, q15_t byteme3)
+                         q15_t byteme1, q7_t byteme2, q7_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -111,7 +111,7 @@ template<typename T1, typename T2, typename TOut>
 void FullyConnectedLayerOptCmsis(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                          S_TENSOR bShift, S_TENSOR oShift,
                          S_TENSOR pOut, S_TENSOR scratch,
-                         q15_t byteme1, q7_t byteme2, q15_t byteme3)
+                         T1 byteme1, T2 byteme2, TOut byteme3)
 {
     //Throw error if this gets called
 }
@@ -120,7 +120,7 @@ template<>
 void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
                                            S_TENSOR pOut, S_TENSOR scratch,
-                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
+                                           q7_t byteme1, q7_t byteme2, q7_t byteme3)
 {
     const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
@@ -141,7 +141,7 @@ template<>
 void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
                                            S_TENSOR pOut, S_TENSOR scratch,
-                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
+                                           q15_t byteme1, q15_t byteme2, q15_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
@@ -160,10 +160,10 @@ void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, 
 }
 
 template<>
-void FullyConnectedLayerOptCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
+void FullyConnectedLayerOptCmsis<q15_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENSOR b,
                                            S_TENSOR bShift, S_TENSOR oShift,
                                            S_TENSOR pOut, S_TENSOR scratch,
-                                           q15_t byteme1, q7_t byteme2, q15_t byteme3)
+                                           q15_t byteme1, q7_t byteme2, q7_t byteme3)
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -33,15 +33,19 @@ void FullyConnectedLayerCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_TENS
 {
     const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_q7(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_q7(iV_data, mW_data, dim_vec, num_of_rows, 
+            bias_shift, out_shift, bias_data, pOut_data, scratch_data);
+    
+
     //Error checking
 }
 template<>
@@ -51,15 +55,17 @@ void FullyConnectedLayerCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_T
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q15_t* bias_data = b->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_q15(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_q15(iV_data, mW_data, dim_vec, num_of_rows, 
+                        bias_shift, out_shift, bias_data, pOut_data, scratch_data);
     //Error checking
 }
 
@@ -70,15 +76,17 @@ void FullyConnectedLayerCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S_TE
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_mat_q7_vec_q15(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_mat_q7_vec_q15(iV_data, mW_data, dim_vec, num_of_rows, 
+                        bias_shift, out_shift, bias_data, pOut_data, scratch_data);
     //Error checking
 }
 
@@ -110,15 +118,17 @@ void FullyConnectedLayerOptCmsis<q7_t, q7_t, q7_t>(S_TENSOR iV, S_TENSOR mW, S_T
 {
     const q7_t* iV_data = iV->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const q7_t* mW_data = mW->read<q7_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q7_t* pOut_data = pOut->write(0, sizeof(q7_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_q7_opt(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_q7_opt(iV_data, mW_data, dim_vec, num_of_rows, 
+                        bias_shift, out_shift, bias_data, pOut_data, scratch_data);
     //Error checking
 }
 template<>
@@ -128,15 +138,17 @@ void FullyConnectedLayerOptCmsis<q15_t, q15_t, q15_t>(S_TENSOR iV, S_TENSOR mW, 
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q15_t* mW_data = mW->read<q15_t>(0, sizeof(q15_t)); //Read one byte
+    const q15_t* bias_data = b->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_q15_opt(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_q15_opt(iV_data, mW_data, dim_vec, num_of_rows, 
+                        bias_shift, out_shift, bias_data, pOut_data, scratch_data);
     //Error checking
 }
 
@@ -147,15 +159,17 @@ void FullyConnectedLayerOptCmsis<q15_t, q7_t, q15_t>(S_TENSOR iV, S_TENSOR mW, S
 {
     const q15_t* iV_data = iV->read<q15_t>(0, sizeof(q15_t)); //Read one byte
     const q7_t* mW_data = mW->read<q15_t>(0, sizeof(q7_t)); //Read one byte
+    const q7_t* bias_data = b->read<q7_t>(0, sizeof(q7_t)); //Read one byte
     const uint16_t dim_vec = iV->getShape()[0];
     const uint16_t num_of_rows = mW->getShape()[0];
     const uint16_t bias_shift = *(bShift->read<uint16_t>(0,0));
     const uint16_t out_shift = *(oShift->read<uint16_t>(0,0));
+    pOut->resize(b->getShape());
     q15_t* pOut_data = pOut->write(0, sizeof(q15_t));
     q15_t* scratch_data = scratch->write(0, sizeof(q15_t));
 
-    arm_fully_connected_mat_q7_vec_q15_opt(iV_data, mW_data, dim_vec, dim_vec, 
-            num_of_rows, bias_shift, out_shift, pOut_data, scratch_data);
+    arm_fully_connected_mat_q7_vec_q15_opt(iV_data, mW_data, dim_vec, num_of_rows, 
+                        bias_shift, out_shift, bias_data, pOut_data, scratch_data);
     //Error checking
 }
 

--- a/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
+++ b/uTensor/ops/cmsis_ops/FullyConnectedOps.hpp
@@ -11,12 +11,8 @@
  * http://www.keil.com/pack/doc/CMSIS/NN/html/group__FC.html#gae3857bb6375692e81dde8cbd70adec08
  */
 
-template<typename T1, typename T2, typename T3>
-void cmsis_fc_selector(const T1* iV, const T2* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
-                       const uint16_t bias_shift, const uint16_t out_shift, const T3* bias, 
-                       T1* pOut, q15_t* scratch_data);
-template<>
-void cmsis_fc_selector<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+//I definitely overcomplicated this part. Should just use f*** function overloading
+void cmsis_fc_selector(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
                        q7_t* pOut, q15_t* scratch_data)
 {
@@ -24,8 +20,7 @@ void cmsis_fc_selector<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const u
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
 
-template<>
-void cmsis_fc_selector<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+void cmsis_fc_selector(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q15_t* bias, 
                        q15_t* pOut, q15_t* scratch_data)
 {
@@ -33,8 +28,7 @@ void cmsis_fc_selector<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, co
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
 
-template<>
-void cmsis_fc_selector<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+void cmsis_fc_selector(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
                        q15_t* pOut, q15_t* scratch_data)
 {
@@ -42,12 +36,7 @@ void cmsis_fc_selector<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, const
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
 
-template<typename T1, typename T2, typename T3>
-void cmsis_fc_selector_opt(const T1* iV, const T2* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
-                       const uint16_t bias_shift, const uint16_t out_shift, const T3* bias, 
-                       T1* pOut, q15_t* scratch_data);
-template<>
-void cmsis_fc_selector_opt<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+void cmsis_fc_selector_opt(const q7_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
                        q7_t* pOut, q15_t* scratch_data)
 {
@@ -55,8 +44,7 @@ void cmsis_fc_selector_opt<q7_t, q7_t, q7_t>(const q7_t* iV, const q7_t* mW, con
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
 
-template<>
-void cmsis_fc_selector_opt<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+void cmsis_fc_selector_opt(const q15_t* iV, const q15_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q15_t* bias, 
                        q15_t* pOut, q15_t* scratch_data)
 {
@@ -64,8 +52,7 @@ void cmsis_fc_selector_opt<q15_t, q15_t, q15_t>(const q15_t* iV, const q15_t* mW
             bias_shift, out_shift, bias, pOut, scratch_data);
 }
 
-template<>
-void cmsis_fc_selector_opt<q15_t, q7_t, q7_t>(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
+void cmsis_fc_selector_opt(const q15_t* iV, const q7_t* mW, const uint16_t dim_vec, const uint16_t num_of_rows,
                        const uint16_t bias_shift, const uint16_t out_shift, const q7_t* bias, 
                        q15_t* pOut, q15_t* scratch_data)
 {

--- a/uTensor/ops/cmsis_ops/activationOps.hpp
+++ b/uTensor/ops/cmsis_ops/activationOps.hpp
@@ -1,0 +1,51 @@
+#ifndef UTENSOR_CMSIS_ACTIVATION_FUNCTIONS
+#define UTENSOR_CMSIS_ACTIVATION_FUNCTIONS
+#include "uTensor/core/tensor.hpp"
+#include "uTensor/core/uTensorBase.hpp"
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+
+
+/**
+ * @param [in] data input tensor
+ */
+template<typename T1, typename TOut>
+void ReluCmsis(S_TENSOR data, S_TENSOR out)
+{
+    //Throw error if this gets called
+}
+
+template<>
+void ReluCmsis<q7_t, q7_t>(S_TENSOR data, S_TENSOR out)
+{
+    out = data;
+    q7_t* d = out->write<q7_t>(0, sizeof(q7_t));
+    uint16_t numel = (uint16_t)out->getSize();
+    arm_relu_q7(d, numel);
+    //Error checking
+}
+
+template<>
+void ReluCmsis<q15_t, q15_t>(S_TENSOR data, S_TENSOR out)
+{
+    out = data;
+    q15_t* d = out->write<q15_t>(0, sizeof(q15_t));
+    uint16_t numel = (uint16_t)out->getSize();
+    arm_relu_q15(d, numel);
+    //Error checking
+}
+
+template <class T1, class TOut>
+class ReluCmsisOp : public Operator {
+  public:
+  ReluCmsisOp() {
+    n_inputs = 1;
+    n_outputs = 1;
+  }
+  virtual void compute() override {
+      ReluCmsis<T1, TOut>(inputs[0], outputs[0]);
+  }
+};
+
+
+#endif 

--- a/uTensor/ops/cmsis_ops/softmax.hpp
+++ b/uTensor/ops/cmsis_ops/softmax.hpp
@@ -1,0 +1,54 @@
+#ifndef UTENSOR_CMSIS_SOFTMAX_FUNCTIONS
+#define UTENSOR_CMSIS_SOFTMAX_FUNCTIONS
+#include "uTensor/core/tensor.hpp"
+#include "uTensor/core/uTensorBase.hpp"
+#include "arm_math.h"
+#include "arm_nnfunctions.h"
+
+
+/**
+ * @param [in] data input tensor
+ */
+template<typename T1, typename TOut>
+void SoftmaxCmsis(S_TENSOR data, S_TENSOR out)
+{
+    //Throw error if this gets called
+}
+
+template<>
+void SoftmaxCmsis<q7_t, q7_t>(S_TENSOR data, S_TENSOR out)
+{
+    const q7_t* in = data->read<q7_t>(0, sizeof(q7_t));
+    out->resize(in->getShape());
+    q7_t* d = out->write<q7_t>(0, sizeof(q7_t));
+    uint16_t numel = (uint16_t)in->getSize();
+    arm_softmax_q7(in, numel, d);
+    //Error checking
+}
+
+template<>
+void SoftmaxCmsis<q15_t, q15_t>(S_TENSOR data, S_TENSOR out)
+{
+    const q15_t* in = data->read<q15_t>(0, sizeof(q15_t));
+    out->resize(in->getShape());
+    q15_t* d = out->write<q15_t>(0, sizeof(q15_t));
+    uint16_t numel = (uint16_t)in->getSize();
+    arm_softmax_q15(in, numel, d);
+    //Error checking
+}
+
+
+template <class T1, class TOut>
+class SoftmaxCmsisOp : public Operator {
+  public:
+  SoftmaxCmsisOp() {
+    n_inputs = 1;
+    n_outputs = 1;
+  }
+  virtual void compute() override {
+      SoftmaxCmsis<T1, TOut>(inputs[0], outputs[0]);
+  }
+};
+
+
+#endif 


### PR DESCRIPTION
Add compile time type checking for CMSIS op selection. 

For example:
```
    ctx.push_static(hold(new FullyConnectedLayerCmsisOp<q7_t,q7_t,q7_t>()), "FcOp", inputs, outputs);
```
Will automatically select the correct CMSIS call