### PR TITLE
Use cmath instead of math.h

### DIFF
--- a/uTensor/ops/ArrayOps.hpp
+++ b/uTensor/ops/ArrayOps.hpp
@@ -5,7 +5,7 @@
 #include "uTensor/util/quantization_utils.hpp"
 #include "uTensor/core/uTensorBase.hpp"
 #include <cstring>
-#include <math.h>
+#include <cmath>
 
 //T = inferred
 //mode = MIN_FIRST


### PR DESCRIPTION
round() is under std namespace only if we are using C++ header.