### PR TITLE
Saving memory consumption from copies of vectors.

### DIFF
--- a/uTensor/core/sdtensor.hpp
+++ b/uTensor/core/sdtensor.hpp
@@ -41,7 +41,7 @@ class SDTensor : public Tensor {
       dirty = false;
     }
 
-    SDTensor(std::vector<uint32_t> v, uint32_t cachesize) : Tensor() {
+    SDTensor(const std::vector<uint32_t>& v, uint32_t cachesize) : Tensor() {
       s->cache_size = cachesize;
       Tensor::init(v);
       string file = tmpprefix + getTmpName();
@@ -94,7 +94,7 @@ class SDTensor : public Tensor {
       }
       return (void*)((T*)s->data);
     }
-    void resize(std::vector<uint32_t> v) override {
+    void resize(const std::vector<uint32_t>& v) override {
         Tensor::resize(v);
         initCache();
     }

--- a/uTensor/core/tensor.cpp
+++ b/uTensor/core/tensor.cpp
@@ -11,7 +11,7 @@ void uTensor::setName(std::string _name)
 std::string uTensor::getName() { return name; }
 inline uTensor::~uTensor(){}
 
-void TensorBase::initialize(std::vector<uint32_t>& vec) 
+void TensorBase::initialize(const std::vector<uint32_t>& vec) 
 {
     uint32_t ret = 0;
     shape.clear();

--- a/uTensor/core/tensor.cpp
+++ b/uTensor/core/tensor.cpp
@@ -8,7 +8,7 @@ void uTensor::setName(std::string _name)
         ERR_EXIT("Tensor %s already has a name %s\r\n", _name.c_str(), name.c_str());
     }
 }
-std::string uTensor::getName() { return name; }
+const std::string& uTensor::getName() const { return name; }
 inline uTensor::~uTensor(){}
 
 void TensorBase::initialize(const std::vector<uint32_t>& vec) 
@@ -96,7 +96,7 @@ void Tensor::resize(const std::vector<uint32_t>& v) {
     s->allocate(unit_size());
 }
 
-std::vector<uint32_t> Tensor::getShape(void) const { return s->shape; }
+const std::vector<uint32_t>& Tensor::getShape(void) const { return s->shape; }
 
 uint32_t Tensor::getSize(void) { return s->total_size; }
 
@@ -124,7 +124,7 @@ void permuteIndexTransform::computeOutputShape(void) {
     }
 }
 
-size_t permuteIndexTransform::evalStride(size_t dim_index, Shape s) {
+size_t permuteIndexTransform::evalStride(size_t dim_index, const Shape& s) {
     unsigned int size_accm = 1;
     for (auto it = s.begin() + dim_index + 1; it != s.end(); it++) {
         size_accm *= *it;
@@ -146,13 +146,15 @@ void permuteIndexTransform::computeOutputStride(void) {
     }
 }
 
-permuteIndexTransform::permuteIndexTransform(Shape input_shape, const std::vector<uint8_t>& permute) {
+permuteIndexTransform::permuteIndexTransform(const Shape& input_shape, const std::vector<uint8_t>& permute) {
     setInputShape(input_shape);
     setPermute(permute);
     apply();
 }
 
-std::vector<uint8_t> permuteIndexTransform::getPermute(void) { return permute; }
+const std::vector<uint8_t>& permuteIndexTransform::getPermute(void) const {
+    return permute;
+}
 
 void permuteIndexTransform::setPermute(const std::vector<uint8_t>& _permute) {
     permute = _permute;
@@ -164,7 +166,7 @@ void permuteIndexTransform::setPermute(const std::vector<uint8_t>& _permute) {
     }
 }
 
-void permuteIndexTransform::setInputShape(Shape s) { in_shape = s; }
+void permuteIndexTransform::setInputShape(const Shape& s) { in_shape = s; }
 Shape permuteIndexTransform::getNewShape(void) { return out_shape; }
 
 void permuteIndexTransform::apply(void) {
@@ -189,7 +191,7 @@ size_t permuteIndexTransform::operator[](const size_t index) {
 }
 
 
-size_t broadcastIndexTransform::evalStride(size_t dim_index, Shape s) {
+size_t broadcastIndexTransform::evalStride(size_t dim_index, const Shape& s) {
     unsigned int size_accm = 1;
     for (auto it = s.begin() + dim_index + 1; it != s.end(); it++) {
         size_accm *= *it;
@@ -211,7 +213,7 @@ void broadcastIndexTransform::computeLStride(void) {
     }
 }
 
-void broadcastIndexTransform::sortShape(Shape a, Shape b) {
+void broadcastIndexTransform::sortShape(const Shape& a, const Shape& b) {
     if(a.size() > b.size()) {
         l_shape = a;
         s_shape = b;
@@ -242,7 +244,7 @@ void broadcastIndexTransform::checkShape(void) {
     }
 }
 
-broadcastIndexTransform::broadcastIndexTransform(Shape _l_shape, Shape _s_shape) {
+broadcastIndexTransform::broadcastIndexTransform(const Shape& _l_shape, const Shape& _s_shape) {
     swap_flag = false;
     sortShape(_l_shape, _s_shape);
     checkShape();
@@ -255,7 +257,7 @@ void broadcastIndexTransform::apply(void) {
     computeSStride();
 }
 
-Shape broadcastIndexTransform::getOutputShape(void) {
+const Shape& broadcastIndexTransform::getOutputShape(void) const {
     return l_shape;
 }
 

--- a/uTensor/core/tensor.cpp
+++ b/uTensor/core/tensor.cpp
@@ -66,7 +66,7 @@ size_t Tensor::getStride(size_t dim_index) {
     return (size_t)size_accm;
 }
 
-void Tensor::init(std::vector<uint32_t>& v) {
+void Tensor::init(const std::vector<uint32_t>& v) {
 
     s->initialize(v);
     if (s->data != NULL) {
@@ -75,7 +75,7 @@ void Tensor::init(std::vector<uint32_t>& v) {
     s->allocate(unit_size());
 }
 
-void Tensor::init(std::vector<uint32_t>& v, const void* data) {
+void Tensor::init(const std::vector<uint32_t>& v, const void* data) {
 
     s->initialize(v);
     if (s->data != NULL) {
@@ -84,7 +84,7 @@ void Tensor::init(std::vector<uint32_t>& v, const void* data) {
     s->data = (void *)data;
 }
 
-void Tensor::resize(std::vector<uint32_t> v) {
+void Tensor::resize(const std::vector<uint32_t>& v) {
     uint32_t size = s->total_size;
 
     s->initialize(v);
@@ -96,7 +96,7 @@ void Tensor::resize(std::vector<uint32_t> v) {
     s->allocate(unit_size());
 }
 
-std::vector<uint32_t> Tensor::getShape(void) { return s->shape; }
+std::vector<uint32_t> Tensor::getShape(void) const { return s->shape; }
 
 uint32_t Tensor::getSize(void) { return s->total_size; }
 
@@ -146,14 +146,15 @@ void permuteIndexTransform::computeOutputStride(void) {
     }
 }
 
-permuteIndexTransform::permuteIndexTransform(Shape input_shape, std::vector<uint8_t> permute) {
+permuteIndexTransform::permuteIndexTransform(Shape input_shape, const std::vector<uint8_t>& permute) {
     setInputShape(input_shape);
     setPermute(permute);
     apply();
 }
 
 std::vector<uint8_t> permuteIndexTransform::getPermute(void) { return permute; }
-void permuteIndexTransform::setPermute(std::vector<uint8_t>& _permute) {
+
+void permuteIndexTransform::setPermute(const std::vector<uint8_t>& _permute) {
     permute = _permute;
     depermute.resize(permute.size());
     uint8_t i = 0;

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -31,7 +31,7 @@ class uTensor {
 public:
  virtual void inFocus(){};
  virtual void deFocus(){};
- virtual std::string getName();
+ virtual const std::string& getName() const;
  virtual void setName(std::string _name);
 
  virtual ~uTensor() = 0;
@@ -74,7 +74,7 @@ class Tensor : public uTensor {
 
   virtual void resize(const std::vector<uint32_t>& v); 
 
-  std::vector<uint32_t> getShape(void) const; 
+  const std::vector<uint32_t>& getShape(void) const; 
 
   uint32_t getSize(void); 
 
@@ -229,18 +229,18 @@ class permuteIndexTransform {
 
   void computeOutputShape(void); 
 
-  size_t evalStride(size_t dim_index, Shape s); 
+  size_t evalStride(size_t dim_index, const Shape& s); 
 
   void computeInputStride(void); 
   void computeOutputStride(void); 
 
  public:
-  permuteIndexTransform(Shape input_shape, const std::vector<uint8_t>& permute); 
+  permuteIndexTransform(const Shape& input_shape, const std::vector<uint8_t>& permute); 
 
-  std::vector<uint8_t> getPermute(void); 
+  const std::vector<uint8_t>& getPermute(void) const;
   void setPermute(const std::vector<uint8_t>& _permute); 
 
-  void setInputShape(Shape s); 
+  void setInputShape(const Shape& s); 
   Shape getNewShape(void); 
 
   void apply(void); 
@@ -259,7 +259,7 @@ void printDim(Tensor* t) {
 }
 
 template <typename T>
-void tensorChkAlloc(Tensor** t, Shape dim) {
+void tensorChkAlloc(Tensor** t, const Shape& dim) {
   if (*t && (*t)->getSize() == 0) {
     (*t)->init(dim);
   } else if (*t && (*t)->getShape() != dim) {
@@ -285,23 +285,23 @@ class broadcastIndexTransform {
   Shape s_stride;
   bool swap_flag;
 
-  size_t evalStride(size_t dim_index, Shape s); 
+  size_t evalStride(size_t dim_index, const Shape& s); 
 
   void computeSStride(void); 
   void computeLStride(void); 
 
-  void sortShape(Shape a, Shape b); 
+  void sortShape(const Shape& a, const Shape& b); 
 
   void checkShape(void); 
 
 
 //b_shape being a smaller shape
  public:
-  broadcastIndexTransform(Shape _l_shape, Shape _s_shape); 
+  broadcastIndexTransform(const Shape& _l_shape, const Shape& _s_shape); 
 
   void apply(void); 
 
-  Shape getOutputShape(void); 
+  const Shape& getOutputShape(void) const;
 
   bool is_swaped(void); 
 

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -48,7 +48,7 @@ class TensorBase {
   uint32_t total_size;
   uint32_t cache_size;
 
-  void initialize(std::vector<uint32_t>& vec);
+  void initialize(const std::vector<uint32_t>& vec);
   void allocate(uint8_t unit_size);
 
   ~TensorBase();

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -68,13 +68,13 @@ class Tensor : public uTensor {
   // returns how far a given dimension is apart
   size_t getStride(size_t dim_index); 
 
-  virtual void init(std::vector<uint32_t>& v); 
+  virtual void init(const std::vector<uint32_t>& v); 
 
-  virtual void init(std::vector<uint32_t>& v, const void* data); 
+  virtual void init(const std::vector<uint32_t>& v, const void* data); 
 
-  virtual void resize(std::vector<uint32_t> v); 
+  virtual void resize(const std::vector<uint32_t>& v); 
 
-  std::vector<uint32_t> getShape(void); 
+  std::vector<uint32_t> getShape(void) const; 
 
   uint32_t getSize(void); 
 
@@ -101,7 +101,7 @@ class Tensor : public uTensor {
 template<class T>
 class BinaryTensor : public Tensor {
   public:
-  BinaryTensor(std::vector<uint32_t> v, const T* g) : Tensor() {
+  BinaryTensor(const std::vector<uint32_t>& v, const T* g) : Tensor() {
     Tensor::init(v, g);
   }
 
@@ -144,7 +144,7 @@ class RamTensor : public Tensor {
     Tensor::init(v);
   }
 
-  RamTensor(std::vector<uint32_t> v) : Tensor() {
+  RamTensor(const std::vector<uint32_t>& v) : Tensor() {
     Tensor::init(v);
   }
 
@@ -191,7 +191,7 @@ Tensor* TensorCast(Tensor* input) {
 }
 
 template <typename T>
-Tensor* TensorConstant(std::vector<uint32_t> shape, T c) {
+Tensor* TensorConstant(const std::vector<uint32_t>& shape, T c) {
   Tensor* output = new RamTensor<T>(shape);
   T* outPrt = output->write<T>(0, 0);
 
@@ -235,10 +235,10 @@ class permuteIndexTransform {
   void computeOutputStride(void); 
 
  public:
-  permuteIndexTransform(Shape input_shape, std::vector<uint8_t> permute); 
+  permuteIndexTransform(Shape input_shape, const std::vector<uint8_t>& permute); 
 
   std::vector<uint8_t> getPermute(void); 
-  void setPermute(std::vector<uint8_t>& _permute); 
+  void setPermute(const std::vector<uint8_t>& _permute); 
 
   void setInputShape(Shape s); 
   Shape getNewShape(void); 


### PR DESCRIPTION
In these patches, I do the following:
1. Passing constant references of vectors instead of passing copies.
2. Return constant references of vectors instead of copies.

The mantra is saving memory consumption from copying vectors.