### PR TITLE
Add code coverage to CI

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -y \
     cmake \
     gcc \
     wget \
+    lcov \
     g++ 
 
 # Install latest CMAKE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,4 +11,17 @@ jobs:
       - run: find uTensor/core/ -type f -exec sed -e 's/\/fs\//\//g' -i {} \;
       - run: cmake .
       - run: make
-      - run: ctest -VV
+      - run: 
+          name: Test
+          command: ctest -VV
+      - run:
+          name: Generate code coverage
+          command: lcov -c --directory . --output-file main_coverage.info
+      - run: genhtml main_coverage.info --output-directory coverage
+      - store_artifacts:
+          path: test-results.xml
+          prefix: tests
+      - store_artifacts:
+          path: coverage
+          prefix: coverage
+        

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: mbartling/utensor_ci
     steps:
       - checkout
+      - run: mkdir -p /tmp/coverage && mkdir -p /tmp/test_results
       - run: git clone https://github.com/ThrowTheSwitch/Unity.git unity_temp
       - run: mv unity_temp/* unity/
       - run: find TESTS -type f -exec sed -e 's/\/fs\//TESTS\//g' -i {} \;
@@ -13,15 +14,14 @@ jobs:
       - run: make
       - run: 
           name: Test
-          command: ctest -VV
+          command: ctest -VV -o /tmp/test_results/test-results.txt
       - run:
           name: Generate code coverage
-          command: lcov -c --directory . --output-file main_coverage.info
-      - run: genhtml main_coverage.info --output-directory coverage
+          command: lcov -c --directory . --output-file main_coverage.info > /tmp/test_results/coverage_summary.txt
+      - run: genhtml main_coverage.info --output-directory /tmp/coverage
+      - store_test_results:
+          path: /tmp/test_results
       - store_artifacts:
-          path: test-results.xml
-          prefix: tests
-      - store_artifacts:
-          path: coverage
+          path: /tmp/coverage
           prefix: coverage
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ else()
         message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
+# Build with code coverage
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 
 add_library(utensor STATIC ${SOURCES})
 


### PR DESCRIPTION
Coverage is in CI->build no->artifacts/tmp/coverage/index.html

![image](https://user-images.githubusercontent.com/5848519/45763815-ebf74580-bbf6-11e8-97f2-c4ce3dfe410a.png)

https://54-107694711-gh.circle-artifacts.com/0/tmp/coverage/index.html
