### PR TITLE
Make TensorShape a dedicated class.

### DIFF
--- a/TESTS/core/tensor/test_core_binarytensor.cpp
+++ b/TESTS/core/tensor/test_core_binarytensor.cpp
@@ -14,7 +14,7 @@ const int val[18] = {3, 5, 6, 7, 8, 9, 10, 21, 9, 32,
                 1, 2, 9, 3, 8, 67, 8, 9};
 void test_core_resizeBinaryTensor() {
     Tensor* a = new BinaryTensor<int>({3, 2, 3}, val);
-    std::vector<uint32_t> v({1, 5, 8});
+    TensorShape v({1, 5, 8});
     a->resize(v);
     bool res = testsize(1 * 5 * 8, a->getSize());
     EXPECT_EQ(res, true); 
@@ -26,18 +26,18 @@ void test_core_reshapeBinaryTensor() {
 
   for (int i = 0; i < 9; i++) {
     std::default_random_engine gen;
-    vector<uint32_t> tmp({3, 2, 3});
+    TensorShape tmp({3, 2, 3});
     std::string a_s = "input" + to_string(i);
     S_TENSOR inputTensor = ctx.add(new BinaryTensor<int>(tmp, val), a_s);
     vector<uint8_t> permute = {2, 1, 0};
-    vector<uint32_t> g = inputTensor->getShape();
+    TensorShape g = inputTensor->getShape();
     std::shuffle(permute.begin(), permute.end(), gen);
 
     permuteIndexTransform trans(inputTensor->getShape(), permute);
 
     std::string a_o = "output" + to_string(i);
     S_TENSOR output = ctx.add(new BinaryTensor<int>(trans.getNewShape(), val), a_o);
-    vector<uint32_t> s = output->getShape();
+    TensorShape s = output->getShape();
     res = testshape<uint32_t>(g, s, permute);
     if (!res) {
       break;

--- a/TESTS/core/tensor/test_core_tensor.cpp
+++ b/TESTS/core/tensor/test_core_tensor.cpp
@@ -13,7 +13,7 @@ Context ctx;
 
 void test_core_resizeTensor() {
     Tensor* a = new RamTensor<int>({3, 2, 3});
-    std::vector<uint32_t> v({1, 5, 8});
+    TensorShape v({1, 5, 8});
     a->resize(v);
     bool res = testsize(1 * 5 * 8, a->getSize());
     EXPECT_EQ(res, true); 
@@ -25,18 +25,18 @@ void test_core_reshapeTensor() {
 
   for (int i = 0; i < 9; i++) {
     std::default_random_engine gen;
-    vector<uint32_t> tmp({2, 3, 4, 5});
+    TensorShape tmp({2, 3, 4, 5});
     std::string a_s = "input" + std::to_string(i);
     S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s);
     vector<uint8_t> permute = {2, 3, 1, 0};
-    vector<uint32_t> g = inputTensor->getShape();
+    TensorShape g = inputTensor->getShape();
     std::shuffle(permute.begin(), permute.end(), gen);
 
     permuteIndexTransform trans(inputTensor->getShape(), permute);
 
     std::string a_o = "output" + std::to_string(i);
     S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o);
-    vector<uint32_t> s = output->getShape();
+    TensorShape s = output->getShape();
     res = testshape<uint32_t>(g, s, permute);
     if (!res) {
       break;

--- a/TESTS/test_helper.h
+++ b/TESTS/test_helper.h
@@ -65,7 +65,7 @@ double meanAbsErr(Tensor* A, Tensor* B) {
   size_B = B->getSize();
   if (A->getSize() != B->getSize()) {
     /* %lu is different for 64bit machines. Need to make this cross platform
-    Shape shape_A, shape_B;
+    TensorShape shape_A, shape_B;
     shape_A = A->getShape();
     shape_B = B->getShape();
     printf("shape_A: ");

--- a/examples/deep_mnist_mlp.cpp
+++ b/examples/deep_mnist_mlp.cpp
@@ -39,7 +39,7 @@ void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
     ctx.add(new RamTensor<float>({1}), "matmul_out_min");
     ctx.add(new RamTensor<float>({1}), "matmul_out_max");
 
-    // printf("QntMulOp Shape:");
+    // printf("QntMulOp TensorShape:");
     // printf("\r\nx :");
     // printVector(ctx.get(x)->getShape());
     // printf("\r\nw :");
@@ -59,7 +59,7 @@ void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
     ctx.add(new RamTensor<float>({1}), "reqnt_out_max");
     ctx.push(new RequantizeOp(), {"out_c", "matmul_out_min", "matmul_out_max", "req_out_min", "req_out_max"}, {"reqnt_out", "reqnt_out_min", "reqnt_out_max"});
 
-    Shape out_shape = out_c->getShape();
+    TensorShape out_shape = out_c->getShape();
     //clean up
 
     S_TENSOR deqnt_out = ctx.add(new RamTensor<float>(), "deqnt_out");

--- a/uTensor/core/sdtensor.hpp
+++ b/uTensor/core/sdtensor.hpp
@@ -28,7 +28,7 @@ class SDTensor : public Tensor {
     }
 
     SDTensor(std::initializer_list<uint32_t> l, uint32_t cachesize) : Tensor() {
-      std::vector<uint32_t> v;
+      TensorShape v;
       for (auto i : l) {
          v.push_back(i);
       }
@@ -41,7 +41,7 @@ class SDTensor : public Tensor {
       dirty = false;
     }
 
-    SDTensor(const std::vector<uint32_t>& v, uint32_t cachesize) : Tensor() {
+    SDTensor(const TensorShape& v, uint32_t cachesize) : Tensor() {
       s->cache_size = cachesize;
       Tensor::init(v);
       string file = tmpprefix + getTmpName();
@@ -94,7 +94,7 @@ class SDTensor : public Tensor {
       }
       return (void*)((T*)s->data);
     }
-    void resize(const std::vector<uint32_t>& v) override {
+    void resize(const TensorShape& v) override {
         Tensor::resize(v);
         initCache();
     }

--- a/uTensor/core/tensor.cpp
+++ b/uTensor/core/tensor.cpp
@@ -11,7 +11,7 @@ void uTensor::setName(std::string _name)
 const std::string& uTensor::getName() const { return name; }
 uTensor::~uTensor(){}
 
-void TensorBase::initialize(const std::vector<uint32_t>& vec) 
+void TensorBase::initialize(const TensorShape& vec) 
 {
     uint32_t ret = 0;
     shape.clear();
@@ -66,7 +66,7 @@ size_t Tensor::getStride(size_t dim_index) {
     return (size_t)size_accm;
 }
 
-void Tensor::init(const std::vector<uint32_t>& v) {
+void Tensor::init(const TensorShape& v) {
 
     s->initialize(v);
     if (s->data != NULL) {
@@ -75,7 +75,7 @@ void Tensor::init(const std::vector<uint32_t>& v) {
     s->allocate(unit_size());
 }
 
-void Tensor::init(const std::vector<uint32_t>& v, const void* data) {
+void Tensor::init(const TensorShape& v, const void* data) {
 
     s->initialize(v);
     if (s->data != NULL) {
@@ -84,7 +84,7 @@ void Tensor::init(const std::vector<uint32_t>& v, const void* data) {
     s->data = (void *)data;
 }
 
-void Tensor::resize(const std::vector<uint32_t>& v) {
+void Tensor::resize(const TensorShape& v) {
     uint32_t size = s->total_size;
 
     s->initialize(v);
@@ -96,7 +96,7 @@ void Tensor::resize(const std::vector<uint32_t>& v) {
     s->allocate(unit_size());
 }
 
-const std::vector<uint32_t>& Tensor::getShape(void) const { return s->shape; }
+const TensorShape& Tensor::getShape(void) const { return s->shape; }
 
 uint32_t Tensor::getSize(void) { return s->total_size; }
 
@@ -124,7 +124,7 @@ void permuteIndexTransform::computeOutputShape(void) {
     }
 }
 
-size_t permuteIndexTransform::evalStride(size_t dim_index, const Shape& s) {
+size_t permuteIndexTransform::evalStride(size_t dim_index, const TensorShape& s) {
     unsigned int size_accm = 1;
     for (auto it = s.begin() + dim_index + 1; it != s.end(); it++) {
         size_accm *= *it;
@@ -146,7 +146,7 @@ void permuteIndexTransform::computeOutputStride(void) {
     }
 }
 
-permuteIndexTransform::permuteIndexTransform(const Shape& input_shape, const std::vector<uint8_t>& permute) {
+permuteIndexTransform::permuteIndexTransform(const TensorShape& input_shape, const std::vector<uint8_t>& permute) {
     setInputShape(input_shape);
     setPermute(permute);
     apply();
@@ -166,8 +166,8 @@ void permuteIndexTransform::setPermute(const std::vector<uint8_t>& _permute) {
     }
 }
 
-void permuteIndexTransform::setInputShape(const Shape& s) { in_shape = s; }
-Shape permuteIndexTransform::getNewShape(void) { return out_shape; }
+void permuteIndexTransform::setInputShape(const TensorShape& s) { in_shape = s; }
+TensorShape permuteIndexTransform::getNewShape(void) { return out_shape; }
 
 void permuteIndexTransform::apply(void) {
     computeOutputShape();
@@ -191,7 +191,7 @@ size_t permuteIndexTransform::operator[](const size_t index) {
 }
 
 
-size_t broadcastIndexTransform::evalStride(size_t dim_index, const Shape& s) {
+size_t broadcastIndexTransform::evalStride(size_t dim_index, const TensorShape& s) {
     unsigned int size_accm = 1;
     for (auto it = s.begin() + dim_index + 1; it != s.end(); it++) {
         size_accm *= *it;
@@ -213,7 +213,7 @@ void broadcastIndexTransform::computeLStride(void) {
     }
 }
 
-void broadcastIndexTransform::sortShape(const Shape& a, const Shape& b) {
+void broadcastIndexTransform::sortShape(const TensorShape& a, const TensorShape& b) {
     if(a.size() > b.size()) {
         l_shape = a;
         s_shape = b;
@@ -244,7 +244,7 @@ void broadcastIndexTransform::checkShape(void) {
     }
 }
 
-broadcastIndexTransform::broadcastIndexTransform(const Shape& _l_shape, const Shape& _s_shape) {
+broadcastIndexTransform::broadcastIndexTransform(const TensorShape& _l_shape, const TensorShape& _s_shape) {
     swap_flag = false;
     sortShape(_l_shape, _s_shape);
     checkShape();
@@ -257,7 +257,7 @@ void broadcastIndexTransform::apply(void) {
     computeSStride();
 }
 
-const Shape& broadcastIndexTransform::getOutputShape(void) const {
+const TensorShape& broadcastIndexTransform::getOutputShape(void) const {
     return l_shape;
 }
 

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -27,6 +27,12 @@ typedef std::vector<TName> TNameList;
 typedef std::shared_ptr<Tensor> S_TENSOR;
 typedef std::vector<S_TENSOR> S_TList;
 
+class TensorShape: public std::vector<uint32_t> {
+    public:
+        using std::vector<uint32_t>::vector;
+
+};
+
 class uTensor {
 public:
  virtual void inFocus(){};
@@ -43,12 +49,12 @@ private:
 //inline uTensor::~uTensor() {}
 class TensorBase {
  public:
-  std::vector<uint32_t> shape;
+  TensorShape shape;
   void* data;
   uint32_t total_size;
   uint32_t cache_size;
 
-  void initialize(const std::vector<uint32_t>& vec);
+  void initialize(const TensorShape& vec);
   void allocate(uint8_t unit_size);
 
   ~TensorBase();
@@ -68,13 +74,13 @@ class Tensor : public uTensor {
   // returns how far a given dimension is apart
   size_t getStride(size_t dim_index); 
 
-  virtual void init(const std::vector<uint32_t>& v); 
+  virtual void init(const TensorShape& v); 
 
-  virtual void init(const std::vector<uint32_t>& v, const void* data); 
+  virtual void init(const TensorShape& v, const void* data); 
 
-  virtual void resize(const std::vector<uint32_t>& v); 
+  virtual void resize(const TensorShape& v); 
 
-  const std::vector<uint32_t>& getShape(void) const; 
+  const TensorShape& getShape(void) const; 
 
   uint32_t getSize(void); 
 
@@ -101,7 +107,7 @@ class Tensor : public uTensor {
 template<class T>
 class BinaryTensor : public Tensor {
   public:
-  BinaryTensor(const std::vector<uint32_t>& v, const T* g) : Tensor() {
+  BinaryTensor(const TensorShape& v, const T* g) : Tensor() {
     Tensor::init(v, g);
   }
 
@@ -136,7 +142,7 @@ class RamTensor : public Tensor {
   RamTensor() {};
 
   RamTensor(std::initializer_list<uint32_t> l) {
-    std::vector<uint32_t> v;
+    TensorShape v;
     for (auto i : l) {
       v.push_back(i);
     }
@@ -144,7 +150,7 @@ class RamTensor : public Tensor {
     Tensor::init(v);
   }
 
-  RamTensor(const std::vector<uint32_t>& v) : Tensor() {
+  RamTensor(const TensorShape& v) : Tensor() {
     Tensor::init(v);
   }
 
@@ -191,7 +197,7 @@ Tensor* TensorCast(Tensor* input) {
 }
 
 template <typename T>
-Tensor* TensorConstant(const std::vector<uint32_t>& shape, T c) {
+Tensor* TensorConstant(const TensorShape& shape, T c) {
   Tensor* output = new RamTensor<T>(shape);
   T* outPrt = output->write<T>(0, 0);
 
@@ -204,7 +210,7 @@ Tensor* TensorConstant(const std::vector<uint32_t>& shape, T c) {
 
 template <typename T>
 Tensor* TensorConstant(std::initializer_list<uint32_t> l, T c) {
-  std::vector<uint32_t> v;
+  TensorShape v;
   for (auto i : l) {
     v.push_back(i);
   }
@@ -222,26 +228,26 @@ class permuteIndexTransform {
  private:
   std::vector<uint8_t> permute;
   std::vector<uint8_t> depermute;
-  Shape in_shape;
-  Shape in_stride;
-  Shape out_shape;
-  Shape out_stride;
+  TensorShape in_shape;
+  TensorShape in_stride;
+  TensorShape out_shape;
+  TensorShape out_stride;
 
   void computeOutputShape(void); 
 
-  size_t evalStride(size_t dim_index, const Shape& s); 
+  size_t evalStride(size_t dim_index, const TensorShape& s); 
 
   void computeInputStride(void); 
   void computeOutputStride(void); 
 
  public:
-  permuteIndexTransform(const Shape& input_shape, const std::vector<uint8_t>& permute); 
+  permuteIndexTransform(const TensorShape& input_shape, const std::vector<uint8_t>& permute); 
 
   const std::vector<uint8_t>& getPermute(void) const;
   void setPermute(const std::vector<uint8_t>& _permute); 
 
-  void setInputShape(const Shape& s); 
-  Shape getNewShape(void); 
+  void setInputShape(const TensorShape& s); 
+  TensorShape getNewShape(void); 
 
   void apply(void); 
 
@@ -251,7 +257,7 @@ class permuteIndexTransform {
 template <typename T>
 void printDim(Tensor* t) {
   printf("Dimension: ");
-  Shape s = t->getShape();
+  TensorShape s = t->getShape();
   for (auto d : s) {
     printf("[%lu] ", d);
   }
@@ -259,7 +265,7 @@ void printDim(Tensor* t) {
 }
 
 template <typename T>
-void tensorChkAlloc(Tensor** t, const Shape& dim) {
+void tensorChkAlloc(Tensor** t, const TensorShape& dim) {
   if (*t && (*t)->getSize() == 0) {
     (*t)->init(dim);
   } else if (*t && (*t)->getShape() != dim) {
@@ -279,29 +285,29 @@ void tensorChkAlloc(Tensor** t, const Shape& dim) {
 
 class broadcastIndexTransform {
  private:
-  Shape l_shape;
-  Shape l_stride;
-  Shape s_shape;
-  Shape s_stride;
+  TensorShape l_shape;
+  TensorShape l_stride;
+  TensorShape s_shape;
+  TensorShape s_stride;
   bool swap_flag;
 
-  size_t evalStride(size_t dim_index, const Shape& s); 
+  size_t evalStride(size_t dim_index, const TensorShape& s); 
 
   void computeSStride(void); 
   void computeLStride(void); 
 
-  void sortShape(const Shape& a, const Shape& b); 
+  void sortShape(const TensorShape& a, const TensorShape& b); 
 
   void checkShape(void); 
 
 
 //b_shape being a smaller shape
  public:
-  broadcastIndexTransform(const Shape& _l_shape, const Shape& _s_shape); 
+  broadcastIndexTransform(const TensorShape& _l_shape, const TensorShape& _s_shape); 
 
   void apply(void); 
 
-  const Shape& getOutputShape(void) const;
+  const TensorShape& getOutputShape(void) const;
 
   bool is_swaped(void); 
 

--- a/uTensor/loaders/tensorIdxImporter.hpp
+++ b/uTensor/loaders/tensorIdxImporter.hpp
@@ -25,7 +25,7 @@ class HeaderMeta {
  public:
   IDX_DTYPE dataType;
   unsigned char numDim;
-  vector<uint32_t> dim;
+  TensorShape dim;
   long int dataPos;
 };
 
@@ -79,7 +79,7 @@ class TensorIdxImporter {
   }
   uint32_t getMagicNumber(unsigned char dtype, unsigned char dim);
   template <typename T>
-  std::vector<uint32_t> load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
+  TensorShape load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
   template <typename T>
   void flush_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data);
   uint8_t getIdxDTypeSize(IDX_DTYPE dtype);
@@ -214,7 +214,7 @@ Tensor* TensorIdxImporter::sdloader(string& filename, IDX_DTYPE idx_type, uint32
 }
 
 template<typename T>
-std::vector<uint32_t> TensorIdxImporter::load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
+TensorShape TensorIdxImporter::load_data(string& filename, IDX_DTYPE idx_type, uint8_t unit_size, uint32_t cachesize, uint32_t arrsize, long int offset, T* data) {
   parseMeta(filename, idx_type);
   if (arrsize == 0) {
     for (auto i : header.dim) {

--- a/uTensor/ops/ArrayOps.hpp
+++ b/uTensor/ops/ArrayOps.hpp
@@ -22,9 +22,9 @@ void QuantizeV2(S_TENSOR input, S_TENSOR _min_range, S_TENSOR _max_range,
     float min_range = std::min(0.0f, input_min_range);
     const float epsilon = std::max(1.0f, std::max(fabsf(input_min_range),
                                                    fabsf(input_max_range))) / 100.0f;
-    std::vector<uint32_t> v;
+    TensorShape v;
 
-    std::vector<uint32_t> org = input->getShape();
+    TensorShape org = input->getShape();
     for (size_t i = 0; i < org.size(); i++) {
         v.push_back(org[i]);
     }
@@ -80,7 +80,7 @@ void dequantize(S_TENSOR input, S_TENSOR min_range, S_TENSOR max_range, S_TENSOR
     float min = *(min_range->read<float>(0, 0));
     float max = *(max_range->read<float>(0, 0));
       //auto tensor allocation
-    Shape out_shape;
+    TensorShape out_shape;
     output->resize(input->getShape());
 
     const T* input_ptr = input->read<T>(0, 0);
@@ -131,7 +131,7 @@ class DequantizeOp : public Operator {
 ///NT: This Op hasn't been tested extensively. We will have to increase the test-coverage for this function.
 template <typename T>
 void reshape(S_TENSOR input, S_TENSOR shape, S_TENSOR output) {
-    Shape dim;
+    TensorShape dim;
 
     auto shape_vec = shape->getShape();
     for(size_t i = 0; i < shape_vec.size(); i++) {

--- a/uTensor/ops/MathOps.hpp
+++ b/uTensor/ops/MathOps.hpp
@@ -36,7 +36,7 @@ void Requantization_Range(S_TENSOR input, S_TENSOR min, S_TENSOR max,
   int32_t used_max_quan;
   CalculateUsedRange<T1>(input.get(), &used_min_quan, &used_max_quan);
 
-  Shape one_shape = {1};
+  TensorShape one_shape = {1};
   if(out_min->getSize() == 0) out_min->resize(one_shape);
   if(out_max->getSize() == 0) out_max->resize(one_shape);
 
@@ -81,7 +81,7 @@ void Requantize(S_TENSOR input, S_TENSOR in_min, S_TENSOR in_max,
   RequantizeManyInNewRangeReference(input_ptr, input->getSize(),input_min,
     input_max, r_output_min, r_output_max, out_ptr);
 
-    Shape one_shape = {1};
+    TensorShape one_shape = {1};
     if(out_min->getSize() == 0) out_min->resize(one_shape);
     if(out_max->getSize() == 0) out_max->resize(one_shape);
 
@@ -124,7 +124,7 @@ void Add(Tensor* input, Tensor* input2, Tensor** out) {
 
 //reduce_shape actual output shape without the reduce dim
 //out_shape intermediate shape with reduce dim in the last orders
-inline void reduceShapeHelper(Shape input, Shape dim, Shape &reduce_shape, Shape &out_shape, std::vector<uint8_t> &perm, size_t &reduce_size) {
+inline void reduceShapeHelper(TensorShape input, TensorShape dim, TensorShape &reduce_shape, TensorShape &out_shape, std::vector<uint8_t> &perm, size_t &reduce_size) {
   reduce_shape.empty();
   out_shape.empty();
   perm.empty();
@@ -151,8 +151,8 @@ inline void reduceShapeHelper(Shape input, Shape dim, Shape &reduce_shape, Shape
 }
 
 template <class TIn, class TOut>
-inline std::vector<TOut> tensorToLinearVec(S_TENSOR input, S_TENSOR dim) {
-  std::vector<TOut> vec;
+inline TensorShape tensorToLinearVec(S_TENSOR input, S_TENSOR dim) {
+  TensorShape vec;
   const TIn* ptr = dim->read<TIn>(0, 0);
   for(auto i = 0; i < (int) dim->getSize(); i++) {
     TIn curr_dim = ptr[i];
@@ -171,14 +171,14 @@ inline std::vector<TOut> tensorToLinearVec(S_TENSOR input, S_TENSOR dim) {
 template <class TIn, class Td, class TOut>
 void MinMaxHelper(S_TENSOR input, S_TENSOR dim, S_TENSOR out, bool find_min) {
   const TIn* p_in = input->read<TIn>(0, 0);
-  Shape dim_vec = tensorToLinearVec<Td, uint32_t>(input, dim);
+  TensorShape dim_vec = tensorToLinearVec<Td, uint32_t>(input, dim);
 
-  Shape outShape;
+  TensorShape outShape;
   std::vector<uint8_t> permute;
   size_t reduce_size;
-  Shape reduce_shape;
+  TensorShape reduce_shape;
   reduceShapeHelper(input->getShape(), dim_vec, reduce_shape, outShape, permute, reduce_size);
-  Shape one_shape = {1};
+  TensorShape one_shape = {1};
   if(out->getSize() == 0) out->resize(reduce_shape);  //TODO: dimension check here
   TOut* p_out = out->write<TOut>(0, 0);
 
@@ -237,7 +237,7 @@ class MaxOp : public Operator {
 template <class TIn, class TOut>
 void ArgMax(S_TENSOR input, S_TENSOR dim, S_TENSOR out) {
   int dim_reduce = *(dim->read<int>(0, 0));
-  Shape outShape = input->getShape();
+  TensorShape outShape = input->getShape();
   uint32_t reduce_dim_size = outShape[dim_reduce];
   outShape.erase(outShape.begin() + dim_reduce);
 
@@ -261,7 +261,7 @@ void ArgMax(S_TENSOR input, S_TENSOR dim, S_TENSOR out) {
   
 
   // construct the origin-shape for permuteIndexTransform
-  Shape vOutShape = outShape;
+  TensorShape vOutShape = outShape;
   vOutShape.push_back(reduce_dim_size);
   /// NT: easy way to remember...
   // trans(originShape, permute)

--- a/uTensor/ops/MatrixOps.hpp
+++ b/uTensor/ops/MatrixOps.hpp
@@ -116,7 +116,7 @@ void QuantizedMatMul(Tensor* A, Tensor* B, Tensor** C,
   const float max_b = *(maxb->read<float>(0, 0));
 
   //auto tensor allocation
-  Shape c_shape;
+  TensorShape c_shape;
   c_shape.push_back((A->getShape())[0]);
   c_shape.push_back((B->getShape())[1]);
   tensorChkAlloc<Toutput>(C, c_shape);
@@ -176,7 +176,7 @@ void QuantizedMatMul2(S_TENSOR A, S_TENSOR B, S_TENSOR C,
 
   //auto tensor allocation
   if(C->getSize() == 0) {
-    Shape c_shape;
+    TensorShape c_shape;
     c_shape.push_back((A->getShape())[0]);
     c_shape.push_back((B->getShape())[1]);
     C->resize(c_shape);
@@ -345,7 +345,7 @@ void QuantizedConv(S_TENSOR input, S_TENSOR filter, S_TENSOR output,
     out_cols = input_cols;
   }
   //TensorShape out_shape({batch, out_rows, out_cols, out_depth});
-  Shape c_shape;
+  TensorShape c_shape;
   c_shape.push_back(batch);
   c_shape.push_back(out_rows);
   c_shape.push_back(out_cols);

--- a/uTensor/ops/NnOps.hpp
+++ b/uTensor/ops/NnOps.hpp
@@ -70,7 +70,7 @@ void SpatialMaxPooling(S_TENSOR input, S_TENSOR output,
   *   - https://www.tensorflow.org/api_guides/python/nn#convolution
   *   - https://www.tensorflow.org/api_guides/python/nn#Notes_on_SAME_Convolution_Padding
   */
-  Shape in_shape = input->getShape();
+  TensorShape in_shape = input->getShape();
   uint32_t n_batch = in_shape[0];
   uint32_t in_rows = in_shape[1];
   uint32_t in_cols = in_shape[2];
@@ -99,7 +99,7 @@ void SpatialMaxPooling(S_TENSOR input, S_TENSOR output,
       pad_left = max(window_cols - (((int) in_cols) % col_stride), 0) / 2;
     }
   }
-  Shape out_shape;
+  TensorShape out_shape;
   out_shape.clear();
   out_shape.push_back(n_batch);
   out_shape.push_back(out_rows);

--- a/uTensor/util/uTensor_util.hpp
+++ b/uTensor/util/uTensor_util.hpp
@@ -60,7 +60,7 @@ void utensor_exit(void);
     utensor_exit();                                          \
   }
 
-typedef std::vector<uint32_t> Shape;
+//typedef std::vector<uint32_t> Shape;
 
 void printVector(std::vector<uint32_t> vec);
 #ifdef TARGET_SIMULATOR


### PR DESCRIPTION
TensorShape looks like a `std::vector<uint32_t>`, behaves like a
`std::vector<uint32_t>`, and literally IS a `std::vector<uint32_t>`, but now
it FORCES us to use TensorShape instead. This makes the code a hell of a
lot more readable.