### PR TITLE
WrappedRamTensor : RamTensor

### DIFF
--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -198,12 +198,14 @@ class WrappedRamTensor : public RamTensor<T> {
   WrappedRamTensor() {};
 
   WrappedRamTensor(std::initializer_list<uint32_t> l, T* ptr) {
-    std::vector<uint32_t> v;
+    TensorShape v;
     for (auto i : l) {
       v.push_back(i);
     }
+
+    void* data = (void *) ptr;
     
-    Tensor::init(v, ptr);
+    Tensor::init(v, data);
   }
 
   void setPointer(void* ptr) {

--- a/uTensor/core/tensor.hpp
+++ b/uTensor/core/tensor.hpp
@@ -137,6 +137,8 @@ class BinaryTensor : public Tensor {
 template <class T>
 class RamTensor : public Tensor {
   // need deep copy
+ protected:
+    using Tensor::s;
  public:
   //RamTensor(TName _name) : Tensor(_name) {}
   RamTensor() {};
@@ -180,6 +182,45 @@ class RamTensor : public Tensor {
  private:
   RamTensor(const RamTensor&);
   RamTensor& operator=(const RamTensor&);
+
+};
+
+
+// application owns the pointer
+// the printer may be modified outside of the application
+template <class T>
+class WrappedRamTensor : public RamTensor<T> {
+
+ protected:
+  using RamTensor<T>::s;
+
+ public:
+  WrappedRamTensor() {};
+
+  WrappedRamTensor(std::initializer_list<uint32_t> l, T* ptr) {
+    std::vector<uint32_t> v;
+    for (auto i : l) {
+      v.push_back(i);
+    }
+    
+    Tensor::init(v, ptr);
+  }
+
+  void setPointer(void* ptr) {
+    s->data = ptr;
+  }
+
+  T* getPointer(void) {
+    return (T*) s->data;
+  }
+
+  ~WrappedRamTensor() {
+    s->data = nullptr;
+  }
+
+ private:
+  WrappedRamTensor(const WrappedRamTensor&);
+  WrappedRamTensor& operator=(const WrappedRamTensor&);
 
 };
 


### PR DESCRIPTION
This class provides an easy way to interface application memory and uTensor.
A memory region can be wrapped into a tensor class by doing:
```
Tensor* input_x = new WrappedRamTensor<float>({1, 784}, (float*) input_data);
```
where `input_data` is allocated in the application or points to a peripheral memory.
