### PR TITLE
  1. modify gc implementation to release final output tensor

### DIFF
--- a/uTensor/core/context.cpp
+++ b/uTensor/core/context.cpp
@@ -213,7 +213,7 @@ uint32_t Context::gc(void) {
 
   for ( auto it : rTable) {
     Ref_Record r = it.second;
-    if(r.count < 1) {
+    if(r.count <= 1) {
       nlist.push_back(it.first);
     }
   }


### PR DESCRIPTION
To avoid the output tensor leaking, we delete all existed tensor (normally would be prediction tensor) by calling gc. #59 on utensor_cgen