### PR TITLE
Allow utensor strings to work without strings

### DIFF
--- a/uTensor/util/utensor_string.hpp
+++ b/uTensor/util/utensor_string.hpp
@@ -1,3 +1,5 @@
+#ifndef UTENSOR_STRING
+#define UTENSOR_STRING
 #include <string.h>
 
 namespace utensor {
@@ -13,7 +15,7 @@ namespace utensor {
                     
                 }
 
-                return v;
+                return (uint32_t) v;
             }
 
         public:
@@ -24,6 +26,7 @@ namespace utensor {
             string(){
                 value = hash("");
             }
+            string(uint32_t val) : value(val), cstr(NULL) {}
             // bool operator < (const string& that){ return this->value < that.value; }
             // bool operator == (const string& that){ return this->value == that.value; }
             bool operator < (const string& that) const { return this->value < that.value; }
@@ -47,3 +50,5 @@ namespace std {
         }
     };
 }
+
+#endif


### PR DESCRIPTION
Luckily, It only takes a couple of lines in the runtime to remove c strings all together.

Turns out The c strings used in models at codegen were being placed on the stack, which is super icky and caused the stack to explode into a ball of sadness at runtime on any reasonable system. This PR allows us to bypass that.