### PR TITLE
Fixed slack and google group links in contributing guide

### DIFF
--- a/contribution_guide.md
+++ b/contribution_guide.md
@@ -1,6 +1,6 @@
 # Contributing to uTensor
 
-Welcome to uTensor contribution guide. Want to make things better? Talk to us directly on [Slack](utensor@slack.com) or our [Google Group](utensor@googlegroups.com)!
+Welcome to uTensor contribution guide. Want to make things better? Talk to us directly on [Slack](https://utensor.slack.com) or our [Google Group](mailto://utensor@googlegroups.com)!
 
 ## Ways to Contribute
 

--- a/contribution_guide.md
+++ b/contribution_guide.md
@@ -1,6 +1,6 @@
 # Contributing to uTensor
 
-Welcome to uTensor contribution guide. Want to make things better? Talk to us directly on [Slack](https://utensor.slack.com) or our [Google Group](mailto://utensor@googlegroups.com)!
+Welcome to uTensor contribution guide. Want to make things better? Talk to us directly on [Slack](http://bit.ly/2LtBmJg) or our [Google Group](mailto://utensor@googlegroups.com)!
 
 ## Ways to Contribute
 


### PR DESCRIPTION
Noticed these were 404ing, found what is hopefully the right links? Feel free to merge or close.