### PR TITLE
TFLM dequantization operator

### DIFF
--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -45,6 +45,7 @@ package_add_test_with_libraries(test_squeeze operators/test_squeeze utensor oper
 package_add_test_with_libraries(test_argmax operators/test_argmax utensor operators "${PROJECT_DIR}/test-data/")
 package_add_test_with_libraries(test_argmin operators/test_argmin utensor operators "${PROJECT_DIR}/test-data/")
 package_add_test_with_libraries(test_reshape operators/test_reshape utensor operators "${PROJECT_DIR}/test-data/")
+package_add_test_with_libraries(test_dequantize operators/test_dequantize.cpp utensor operators "${PROJECT_DIR}/test-data/")
 
 package_add_test_with_libraries(test_top_include library/test_top_include utensor library "${PROJECT_DIR}/test-data/")
 

--- a/TESTS/operators/test_dequantize.cpp
+++ b/TESTS/operators/test_dequantize.cpp
@@ -22,7 +22,6 @@ int offset = -14;
 float scale = 0.11707353591918945f;
 
 TEST(Quantization, DequantizeOp) {
-//    ASSERT_EQ(0,1);
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -34,8 +33,7 @@ TEST(Quantization, DequantizeOp) {
   Tensor b = new /*const*/ BufferTensor({10}, flt, s_b);
 
   TFLM::DequantizeOperator<float, int8_t> deq_A;
-  // add_AB.set_inputs(FixedTensorMap<2>({{MatrixMultOperator<uint8_t>::a, a},
-  // {MatrixMultOperator<uint8_t>::b, b}})).set_outputs({{MatrixMultOperator<uint8_t>::c, c}});
+  
   deq_A
       .set_inputs({{TFLM::DequantizeOperator<float,uint8_t>::a, a}})
       .set_outputs({{TFLM::DequantizeOperator<float,uint8_t>::b, b}})

--- a/TESTS/operators/test_dequantize.cpp
+++ b/TESTS/operators/test_dequantize.cpp
@@ -1,0 +1,51 @@
+#include <cstring>
+#include <iostream>
+
+#include "QuantizeOps.hpp"
+#include "BufferTensor.hpp"
+#include "RamTensor.hpp"
+#include "RomTensor.hpp"
+#include "arenaAllocator.hpp"
+#include "context.hpp"
+#include "gtest/gtest.h"
+#include "quantizationPrimitives.hpp"
+using std::cout;
+using std::endl;
+
+using namespace uTensor;
+
+const int8_t s_a[10] = {-33, -38,  -5,  -5, -49, -41, -95,  98, -36, 0};
+float s_b[10] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+const float ref_b[10] = {-2.2243972, -2.8097649,  1.0536618,  1.0536618, -4.0975738, -3.1609855,
+  -9.482957,  13.112236,  -2.5756178,  1.6390295};
+int offset = -14;
+float scale = 0.11707353591918945f;
+
+TEST(Quantization, DequantizeOp) {
+//    ASSERT_EQ(0,1);
+  localCircularArenaAllocator<256> meta_allocator;
+  localCircularArenaAllocator<256> ram_allocator;
+  Context::get_default_context()->set_metadata_allocator(&meta_allocator);
+  Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
+
+  Tensor a = new /*const*/ RomTensor({10}, i8, s_a);
+  a->set_quantization_params(PerTensorQuantizationParams(offset, scale));
+
+  Tensor b = new /*const*/ BufferTensor({10}, flt, s_b);
+
+  TFLM::DequantizeOperator<float, int8_t> deq_A;
+  // add_AB.set_inputs(FixedTensorMap<2>({{MatrixMultOperator<uint8_t>::a, a},
+  // {MatrixMultOperator<uint8_t>::b, b}})).set_outputs({{MatrixMultOperator<uint8_t>::c, c}});
+  deq_A
+      .set_inputs({{TFLM::DequantizeOperator<float,uint8_t>::a, a}})
+      .set_outputs({{TFLM::DequantizeOperator<float,uint8_t>::b, b}})
+      .eval();
+
+  // Compare results
+  TensorShape& b_shape = b->get_shape();
+  for (int i = 0; i < b_shape[0]; i++) {
+    // Just need to cast the output
+    // FIXME: rounding error due to simplified kernel and support functions
+    EXPECT_LE((float)b(i) - ref_b[i], 1e-5f);
+  }
+}

--- a/src/uTensor/core/quantizationPrimitives.cpp
+++ b/src/uTensor/core/quantizationPrimitives.cpp
@@ -9,23 +9,23 @@ QuantizationParams::QuantizationParams(const int32_t* zp, const float* scale,
     : _zp(zp), _scale(scale), _num_channels(num_channels) {}
 
 QuantizationParams::~QuantizationParams() {}
-int32_t QuantizationParams::get_zeroP_for_channel(int i) { return 0; }
-float QuantizationParams::get_scale_for_channel(int i) { return 0; }
+int32_t const QuantizationParams::get_zeroP_for_channel(int i) const { return *_zp; }
+float const QuantizationParams::get_scale_for_channel(int i) const { return *_scale; }
 
 PerTensorQuantizationParams::PerTensorQuantizationParams(const int32_t& zp,
                                                          const float& scale)
     : QuantizationParams(&zp, &scale, 1) {}
-int32_t PerTensorQuantizationParams::get_zeroP_for_channel(int i) {
+int32_t const PerTensorQuantizationParams::get_zeroP_for_channel(int i) const {
   return _zp[0];
 }
-float PerTensorQuantizationParams::get_scale_for_channel(int i) {
+float const PerTensorQuantizationParams::get_scale_for_channel(int i) const {
   return _scale[0];
 }
 
-int32_t PerChannelQuantizationParams::get_zeroP_for_channel(int i) {
+int32_t const PerChannelQuantizationParams::get_zeroP_for_channel(int i) const {
   return _zp[i];
 }
-float PerChannelQuantizationParams::get_scale_for_channel(int i) {
+float const PerChannelQuantizationParams::get_scale_for_channel(int i) const {
   return _scale[i];
 }
 

--- a/src/uTensor/core/quantizationPrimitives.cpp
+++ b/src/uTensor/core/quantizationPrimitives.cpp
@@ -9,23 +9,23 @@ QuantizationParams::QuantizationParams(const int32_t* zp, const float* scale,
     : _zp(zp), _scale(scale), _num_channels(num_channels) {}
 
 QuantizationParams::~QuantizationParams() {}
-int32_t const QuantizationParams::get_zeroP_for_channel(int i) const { return *_zp; }
-float const QuantizationParams::get_scale_for_channel(int i) const { return *_scale; }
+int32_t QuantizationParams::get_zeroP_for_channel(int i) const { return *_zp; }
+float QuantizationParams::get_scale_for_channel(int i) const { return *_scale; }
 
 PerTensorQuantizationParams::PerTensorQuantizationParams(const int32_t& zp,
                                                          const float& scale)
     : QuantizationParams(&zp, &scale, 1) {}
-int32_t const PerTensorQuantizationParams::get_zeroP_for_channel(int i) const {
+int32_t PerTensorQuantizationParams::get_zeroP_for_channel(int i) const {
   return _zp[0];
 }
-float const PerTensorQuantizationParams::get_scale_for_channel(int i) const {
+float PerTensorQuantizationParams::get_scale_for_channel(int i) const {
   return _scale[0];
 }
 
-int32_t const PerChannelQuantizationParams::get_zeroP_for_channel(int i) const {
+int32_t PerChannelQuantizationParams::get_zeroP_for_channel(int i) const {
   return _zp[i];
 }
-float const PerChannelQuantizationParams::get_scale_for_channel(int i) const {
+float PerChannelQuantizationParams::get_scale_for_channel(int i) const {
   return _scale[i];
 }
 

--- a/src/uTensor/core/quantizationPrimitives.hpp
+++ b/src/uTensor/core/quantizationPrimitives.hpp
@@ -15,8 +15,8 @@ class QuantizationParams {
   QuantizationParams& operator=(QuantizationParams&&) = default;
 
   virtual ~QuantizationParams();
-  virtual int32_t get_zeroP_for_channel(int i);
-  virtual float get_scale_for_channel(int i);
+  virtual int32_t const get_zeroP_for_channel(int i) const;
+  virtual float const get_scale_for_channel(int i) const;
   inline const int num_channels() const { return _num_channels; };
 
  protected:
@@ -38,8 +38,8 @@ inline bool is_per_channel_quantization(const QuantizationParams& params) {
 class PerTensorQuantizationParams : public QuantizationParams {
  public:
   PerTensorQuantizationParams(const int32_t& zp, const float& scale);
-  virtual int32_t get_zeroP_for_channel(int i) override;
-  virtual float get_scale_for_channel(int i) override;
+  virtual int32_t const get_zeroP_for_channel(int i) const override;
+  virtual float const get_scale_for_channel(int i) const override;
   // virtual inline const int num_channels() { return _num_channels; };
 };
 
@@ -54,8 +54,8 @@ class PerChannelQuantizationParams : public QuantizationParams {
                                const int32_t (&scale)[num_channels])
       : QuantizationParams(zp, scale, num_channels) {}
 
-  virtual int32_t get_zeroP_for_channel(int i) override;
-  virtual float get_scale_for_channel(int i) override;
+  virtual int32_t const get_zeroP_for_channel(int i) const override;
+  virtual float const get_scale_for_channel(int i) const override;
 };
 
 }  // namespace uTensor

--- a/src/uTensor/core/quantizationPrimitives.hpp
+++ b/src/uTensor/core/quantizationPrimitives.hpp
@@ -15,8 +15,8 @@ class QuantizationParams {
   QuantizationParams& operator=(QuantizationParams&&) = default;
 
   virtual ~QuantizationParams();
-  virtual int32_t const get_zeroP_for_channel(int i) const;
-  virtual float const get_scale_for_channel(int i) const;
+  virtual int32_t get_zeroP_for_channel(int i) const;
+  virtual float get_scale_for_channel(int i) const;
   inline const int num_channels() const { return _num_channels; };
 
  protected:
@@ -38,8 +38,8 @@ inline bool is_per_channel_quantization(const QuantizationParams& params) {
 class PerTensorQuantizationParams : public QuantizationParams {
  public:
   PerTensorQuantizationParams(const int32_t& zp, const float& scale);
-  virtual int32_t const get_zeroP_for_channel(int i) const override;
-  virtual float const get_scale_for_channel(int i) const override;
+  virtual int32_t get_zeroP_for_channel(int i) const override;
+  virtual float get_scale_for_channel(int i) const override;
   // virtual inline const int num_channels() { return _num_channels; };
 };
 
@@ -54,8 +54,8 @@ class PerChannelQuantizationParams : public QuantizationParams {
                                const int32_t (&scale)[num_channels])
       : QuantizationParams(zp, scale, num_channels) {}
 
-  virtual int32_t const get_zeroP_for_channel(int i) const override;
-  virtual float const get_scale_for_channel(int i) const override;
+  virtual int32_t get_zeroP_for_channel(int i) const override;
+  virtual float get_scale_for_channel(int i) const override;
 };
 
 }  // namespace uTensor

--- a/src/uTensor/ops/QuantizeOps.hpp
+++ b/src/uTensor/ops/QuantizeOps.hpp
@@ -1,0 +1,44 @@
+#ifndef UTENSOR_QUANTIZE_OPS_H
+#define UTENSOR_QUANTIZE_OPS_H
+#include <algorithm>
+#include <limits>
+
+#include "operatorBase.hpp"
+
+namespace uTensor {
+namespace TFLM {
+// https://github.com/tensorflow/tensorflow/blob/fb4ec5cbde3973050e7350f0aca7f07ab7757bac/tensorflow/lite/kernels/internal/reference/dequantize.h#L30-L44
+template <typename OutputT, typename InputT>
+void dequantize_kernel(Tensor& b, const Tensor& a) {
+  
+  // More extensive dimensional checks can be included here
+  const int flat_size = b->get_shape().get_linear_size();
+  const QuantizationParams& quantParam = a->get_quantization_params();
+  int32_t zero_point = quantParam.get_zeroP_for_channel(0);
+  float scale = quantParam.get_scale_for_channel(0);
+
+  for (int i = 0; i < flat_size; i++) {
+    const int32_t val = static_cast<InputT>(a(i));
+    OutputT result = static_cast<OutputT>(scale * static_cast<float>((val - zero_point)));
+    b(i) = result;
+  }
+}
+
+template <typename oT, typename iT>
+class DequantizeOperator : public OperatorInterface<1, 1> {
+ public:
+  enum names_in : uint8_t { a };
+  enum names_out : uint8_t { b };
+  // AddOperator(FixedTensorMap<2> inputs, FixedTensorMap<1> outputs) :
+  // OperatorBase(inputs, outputs) {}
+
+ protected:
+  virtual void compute() {
+    dequantize_kernel<oT, iT>(outputs[b].tensor(), inputs[a].tensor());
+  }
+};
+
+}  //namespace TFLM
+}  // namespace uTensor
+
+#endif


### PR DESCRIPTION
Single test case included: `TESTS/operators/test_dequantize.cpp`
Rounding error of ~1e-6 may result from an approximation of the original equation:
`src/uTensor/ops/QuantizeOps.hpp`
see TFLM's dequantization op for more detail