### PR TITLE
Re arch rc1 op namespacing and alignment

### DIFF
--- a/TESTS/library/test_top_include.cpp
+++ b/TESTS/library/test_top_include.cpp
@@ -7,11 +7,12 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 const uint8_t s_b[25] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                          13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
 
-TEST(Arithmetic, AddOp) {
+TEST(TopInclude, AddOp) {
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);

--- a/TESTS/model/integration_test.cpp
+++ b/TESTS/model/integration_test.cpp
@@ -6,6 +6,11 @@
 #include "uTensor.h"
 
 using namespace uTensor;
+using TflmSymQuantOps::QuantizeOperator;
+using TflmSymQuantOps::DequantizeOperator;
+using TflmSymQuantOps::QuantizedFullyConnectedOperator;
+using TflmSymQuantOps::QuantizedDepthwiseSeparableConvOperator;
+using uTensor::TFLM::TfLiteFusedActivation;
 
 void compute_model(Tensor& input_10, Tensor& Identity0);
 
@@ -84,22 +89,22 @@ TEST(Integration, run_10x_mem_check) {
 
 void compute_model(Tensor& input_10, Tensor& Identity0) {
   // start rendering local declare snippets
-  TFLM::QuantizeOperator<int8_t, float> op_000;
+  QuantizeOperator<int8_t, float> op_000;
 
   QuantizedFullyConnectedOperator<int8_t> op_001(
-      TFLM::TfLiteFusedActivation::kTfLiteActRelu);
+      TfLiteFusedActivation::kTfLiteActRelu);
 
   QuantizedDepthwiseSeparableConvOperator<int8_t> op_002(
-      {1, 1}, VALID, 32, {1, 1}, TFLM::TfLiteFusedActivation::kTfLiteActRelu);
+      {1, 1}, VALID, 32, {1, 1}, TfLiteFusedActivation::kTfLiteActRelu);
 
   MaxPoolOperator<int8_t> op_003({2, 2}, {1, 2, 2, 1}, VALID);
 
   ReshapeOperator<int8_t> op_004({1, 5408});
 
-  TFLM::DequantizeOperator<float, int8_t> op_005;
+  DequantizeOperator<float, int8_t> op_005;
 
   QuantizedFullyConnectedOperator<int8_t> op_006(
-      TFLM::TfLiteFusedActivation::kTfLiteActNone);
+      TfLiteFusedActivation::kTfLiteActNone);
 
   Tensor input_1_int80 = new RamTensor({1, 28, 28, 1}, i8);
   int input_1_int80_zp = -128;
@@ -267,10 +272,10 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
   // start rendering eval snippets
   op_000
       .set_inputs({
-          {TFLM::QuantizeOperator<int8_t, float>::input, input_10},
+          {QuantizeOperator<int8_t, float>::input, input_10},
       })
       .set_outputs(
-          {{TFLM::QuantizeOperator<int8_t, float>::output, input_1_int80}})
+          {{QuantizeOperator<int8_t, float>::output, input_1_int80}})
       .eval();
 
   op_002
@@ -332,9 +337,9 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
 
   op_005
       .set_inputs({
-          {TFLM::DequantizeOperator<float, int8_t>::a, Identity_int80},
+          {DequantizeOperator<float, int8_t>::a, Identity_int80},
       })
-      .set_outputs({{TFLM::DequantizeOperator<float, int8_t>::b, Identity0}})
+      .set_outputs({{DequantizeOperator<float, int8_t>::b, Identity0}})
       .eval();
   // end of rendering eval snippets
 }

--- a/TESTS/model/integration_test.cpp
+++ b/TESTS/model/integration_test.cpp
@@ -9,8 +9,10 @@ using namespace uTensor;
 using TflmSymQuantOps::QuantizeOperator;
 using TflmSymQuantOps::DequantizeOperator;
 using TflmSymQuantOps::QuantizedFullyConnectedOperator;
-using TflmSymQuantOps::QuantizedDepthwiseSeparableConvOperator;
+using TflmSymQuantOps::DepthwiseSeparableConvOperator;
 using uTensor::TFLM::TfLiteFusedActivation;
+using ReferenceOperators::MaxPoolOperator;
+using ReferenceOperators::ReshapeOperator;
 
 void compute_model(Tensor& input_10, Tensor& Identity0);
 
@@ -94,7 +96,7 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
   QuantizedFullyConnectedOperator<int8_t> op_001(
       TfLiteFusedActivation::kTfLiteActRelu);
 
-  QuantizedDepthwiseSeparableConvOperator<int8_t> op_002(
+  DepthwiseSeparableConvOperator<int8_t> op_002(
       {1, 1}, VALID, 32, {1, 1}, TfLiteFusedActivation::kTfLiteActRelu);
 
   MaxPoolOperator<int8_t> op_003({2, 2}, {1, 2, 2, 1}, VALID);
@@ -280,13 +282,13 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
 
   op_002
       .set_inputs({
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::in, input_1_int80},
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::filter,
+          {DepthwiseSeparableConvOperator<int8_t>::in, input_1_int80},
+          {DepthwiseSeparableConvOperator<int8_t>::filter,
            StatefulPartitionedCallmy_modelconv2dConv2DReadVariableOp0},
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::bias,
+          {DepthwiseSeparableConvOperator<int8_t>::bias,
            StatefulPartitionedCallmy_modelconv2dConv2D_bias0},
       })
-      .set_outputs({{QuantizedDepthwiseSeparableConvOperator<int8_t>::out,
+      .set_outputs({{DepthwiseSeparableConvOperator<int8_t>::out,
                      StatefulPartitionedCallmy_modelconv2dRelu0}})
       .eval();
 

--- a/TESTS/model/integration_test.cpp
+++ b/TESTS/model/integration_test.cpp
@@ -8,7 +8,7 @@
 using namespace uTensor;
 using TflmSymQuantOps::QuantizeOperator;
 using TflmSymQuantOps::DequantizeOperator;
-using TflmSymQuantOps::QuantizedFullyConnectedOperator;
+using TflmSymQuantOps::FullyConnectedOperator;
 using TflmSymQuantOps::DepthwiseSeparableConvOperator;
 using uTensor::TFLM::TfLiteFusedActivation;
 using ReferenceOperators::MaxPoolOperator;
@@ -93,7 +93,7 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
   // start rendering local declare snippets
   QuantizeOperator<int8_t, float> op_000;
 
-  QuantizedFullyConnectedOperator<int8_t> op_001(
+  FullyConnectedOperator<int8_t> op_001(
       TfLiteFusedActivation::kTfLiteActRelu);
 
   DepthwiseSeparableConvOperator<int8_t> op_002(
@@ -105,7 +105,7 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
 
   DequantizeOperator<float, int8_t> op_005;
 
-  QuantizedFullyConnectedOperator<int8_t> op_006(
+  FullyConnectedOperator<int8_t> op_006(
       TfLiteFusedActivation::kTfLiteActNone);
 
   Tensor input_1_int80 = new RamTensor({1, 28, 28, 1}, i8);
@@ -313,28 +313,28 @@ void compute_model(Tensor& input_10, Tensor& Identity0) {
 
   op_001
       .set_inputs({
-          {QuantizedFullyConnectedOperator<int8_t>::input,
+          {FullyConnectedOperator<int8_t>::input,
            StatefulPartitionedCallmy_modelmax_pooling2dMaxPool_0_Reshape00},
-          {QuantizedFullyConnectedOperator<int8_t>::filter,
+          {FullyConnectedOperator<int8_t>::filter,
            StatefulPartitionedCallmy_modeldenseMatMulReadVariableOptranspose0},
-          {QuantizedFullyConnectedOperator<int8_t>::bias,
+          {FullyConnectedOperator<int8_t>::bias,
            StatefulPartitionedCallmy_modeldenseMatMul_bias0},
       })
-      .set_outputs({{QuantizedFullyConnectedOperator<int8_t>::output,
+      .set_outputs({{FullyConnectedOperator<int8_t>::output,
                      StatefulPartitionedCallmy_modeldenseRelu0}})
       .eval();
 
   op_006
       .set_inputs({
-          {QuantizedFullyConnectedOperator<int8_t>::input,
+          {FullyConnectedOperator<int8_t>::input,
            StatefulPartitionedCallmy_modeldenseRelu0},
-          {QuantizedFullyConnectedOperator<int8_t>::filter,
+          {FullyConnectedOperator<int8_t>::filter,
            StatefulPartitionedCallmy_modeldense_1MatMulReadVariableOptranspose0},
-          {QuantizedFullyConnectedOperator<int8_t>::bias,
+          {FullyConnectedOperator<int8_t>::bias,
            StatefulPartitionedCallmy_modeldense_1MatMul_bias0},
       })
       .set_outputs(
-          {{QuantizedFullyConnectedOperator<int8_t>::output, Identity_int80}})
+          {{FullyConnectedOperator<int8_t>::output, Identity_int80}})
       .eval();
 
   op_005

--- a/TESTS/model/test_layer_3_dws_conv2d.cpp
+++ b/TESTS/model/test_layer_3_dws_conv2d.cpp
@@ -3,7 +3,7 @@
 #include "uTensor.h"
 
 using namespace uTensor;
-using TflmSymQuantOps::QuantizedDepthwiseSeparableConvOperator;
+using TflmSymQuantOps::DepthwiseSeparableConvOperator;
 
 static localCircularArenaAllocator<2048> ram_allocator;
 static localCircularArenaAllocator<2048> meta_allocator;
@@ -28,16 +28,16 @@ TEST(LayerByLayer, DWSConv2D_3) {
   PerTensorQuantizationParams out_params(out_zp, out_scale);
   output->set_quantization_params(out_params);
 
-  QuantizedDepthwiseSeparableConvOperator<int8_t> op({2, 2}, SAME, 10, {1, 1},
+  DepthwiseSeparableConvOperator<int8_t> op({2, 2}, SAME, 10, {1, 1},
                                                      ::TFLM::kTfLiteActNone);
   op
       .set_inputs({
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::in, input},
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::filter, filter},
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::bias, bias},
+          {DepthwiseSeparableConvOperator<int8_t>::in, input},
+          {DepthwiseSeparableConvOperator<int8_t>::filter, filter},
+          {DepthwiseSeparableConvOperator<int8_t>::bias, bias},
       })
       .set_outputs({
-          {QuantizedDepthwiseSeparableConvOperator<int8_t>::out, output},
+          {DepthwiseSeparableConvOperator<int8_t>::out, output},
       })
       .eval();
   for (int i = 0; i < 250; ++i) {

--- a/TESTS/model/test_layer_3_dws_conv2d.cpp
+++ b/TESTS/model/test_layer_3_dws_conv2d.cpp
@@ -3,6 +3,7 @@
 #include "uTensor.h"
 
 using namespace uTensor;
+using TflmSymQuantOps::QuantizedDepthwiseSeparableConvOperator;
 
 static localCircularArenaAllocator<2048> ram_allocator;
 static localCircularArenaAllocator<2048> meta_allocator;

--- a/TESTS/model/test_layer_4_maxpool.cpp
+++ b/TESTS/model/test_layer_4_maxpool.cpp
@@ -3,6 +3,7 @@
 #include "uTensor.h"
 
 using namespace uTensor;
+using ReferenceOperators::MaxPoolOperator;
 
 static localCircularArenaAllocator<2048> ram_allocator;
 static localCircularArenaAllocator<2048> meta_allocator;

--- a/TESTS/model/test_model1.cpp
+++ b/TESTS/model/test_model1.cpp
@@ -8,6 +8,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 const uint8_t s_a[4] = {1, 2, 3, 4};
 const uint8_t s_b[4] = {5, 6, 7, 8};

--- a/TESTS/model/test_model2.cpp
+++ b/TESTS/model/test_model2.cpp
@@ -8,6 +8,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 const uint8_t s_a[4] = {1, 2, 3, 4};
 const uint8_t s_b[4] = {5, 6, 7, 8};

--- a/TESTS/operators/test_argmax.cpp
+++ b/TESTS/operators/test_argmax.cpp
@@ -11,6 +11,8 @@
 
 using namespace uTensor;
 
+using namespace uTensor::ReferenceOperators;
+ 
 TEST(ArgMax, random_argmax_test) {
   localCircularArenaAllocator<1024> meta_allocator;
   localCircularArenaAllocator<10 * 2 * sizeof(float), uint32_t> ram_allocator;

--- a/TESTS/operators/test_argmin.cpp
+++ b/TESTS/operators/test_argmin.cpp
@@ -10,7 +10,8 @@
 #include "gtest/gtest.h"
 
 using namespace uTensor;
-
+using  uTensor::ReferenceOperators::ArgMinOperator;
+ 
 TEST(ArgMin, random_argmin_test) {
   localCircularArenaAllocator<1024> meta_allocator;
   localCircularArenaAllocator<10 * 2 * sizeof(float), uint32_t> ram_allocator;

--- a/TESTS/operators/test_arithmetic.cpp
+++ b/TESTS/operators/test_arithmetic.cpp
@@ -12,6 +12,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 const uint8_t s_b[25] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                          13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};

--- a/TESTS/operators/test_avgpool.cpp
+++ b/TESTS/operators/test_avgpool.cpp
@@ -14,6 +14,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 /*********************************************
  * Generated Test number

--- a/TESTS/operators/test_convolution.cpp
+++ b/TESTS/operators/test_convolution.cpp
@@ -14,6 +14,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 #define DO_STRIDE_TESTS 1
 /*********************************************

--- a/TESTS/operators/test_dequantize.cpp
+++ b/TESTS/operators/test_dequantize.cpp
@@ -13,6 +13,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace TflmSymQuantOps;
 
 const int8_t s_a[10] = {-33, -38, -5, -5, -49, -41, -95, 98, -36, 0};
 float s_b[10] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
@@ -33,10 +34,11 @@ TEST(Quantization, DequantizeOp) {
 
   Tensor b = new /*const*/ BufferTensor({10}, flt, s_b);
 
-  TFLM::DequantizeOperator<float, int8_t> deq_A;
-
-  deq_A.set_inputs({{TFLM::DequantizeOperator<float, uint8_t>::a, a}})
-      .set_outputs({{TFLM::DequantizeOperator<float, uint8_t>::b, b}})
+  DequantizeOperator<float, int8_t> deq_A;
+  
+  deq_A
+      .set_inputs({{DequantizeOperator<float,uint8_t>::a, a}})
+      .set_outputs({{DequantizeOperator<float,uint8_t>::b, b}})
       .eval();
 
   // Compare results

--- a/TESTS/operators/test_dws_convolution.cpp
+++ b/TESTS/operators/test_dws_convolution.cpp
@@ -14,6 +14,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 /*********************************************
  * Generated Test number

--- a/TESTS/operators/test_matrix.cpp
+++ b/TESTS/operators/test_matrix.cpp
@@ -12,6 +12,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 const uint8_t s_a[4] = {1, 2, 3, 4};
 const uint8_t s_b[4] = {5, 6, 7, 8};

--- a/TESTS/operators/test_maxpool.cpp
+++ b/TESTS/operators/test_maxpool.cpp
@@ -14,6 +14,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 /*********************************************
  * Generated Test number

--- a/TESTS/operators/test_quant_fully_connect_2.cpp
+++ b/TESTS/operators/test_quant_fully_connect_2.cpp
@@ -3,6 +3,7 @@
 #include "uTensor.h"
 
 using namespace uTensor;
+using TflmSymQuantOps::QuantizedFullyConnectedOperator;
 
 TEST(Quantization, QuantFullyConnectOp_2) {
   localCircularArenaAllocator<2048> meta_allocator;

--- a/TESTS/operators/test_quant_fully_connect_2.cpp
+++ b/TESTS/operators/test_quant_fully_connect_2.cpp
@@ -3,7 +3,7 @@
 #include "uTensor.h"
 
 using namespace uTensor;
-using TflmSymQuantOps::QuantizedFullyConnectedOperator;
+using TflmSymQuantOps::FullyConnectedOperator;
 
 TEST(Quantization, QuantFullyConnectOp_2) {
   localCircularArenaAllocator<2048> meta_allocator;
@@ -27,12 +27,12 @@ TEST(Quantization, QuantFullyConnectOp_2) {
   PerTensorQuantizationParams out_params(out_zp_2, out_scale_2);
   output->set_quantization_params(out_params);
 
-  QuantizedFullyConnectedOperator<int8_t> op(
+  FullyConnectedOperator<int8_t> op(
       TFLM::TfLiteFusedActivation::kTfLiteActNone);
-  op.set_inputs({{QuantizedFullyConnectedOperator<int8_t>::input, input},
-                 {QuantizedFullyConnectedOperator<int8_t>::filter, filter},
-                 {QuantizedFullyConnectedOperator<int8_t>::bias, bias}})
-      .set_outputs({{QuantizedFullyConnectedOperator<int8_t>::output, output}})
+  op.set_inputs({{FullyConnectedOperator<int8_t>::input, input},
+                 {FullyConnectedOperator<int8_t>::filter, filter},
+                 {FullyConnectedOperator<int8_t>::bias, bias}})
+      .set_outputs({{FullyConnectedOperator<int8_t>::output, output}})
       .eval();
 
   for (int i = 0; i < output->num_elems(); ++i) {

--- a/TESTS/operators/test_quantize.cpp
+++ b/TESTS/operators/test_quantize.cpp
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 
 using namespace uTensor;
+using namespace TflmSymQuantOps;
 
 TEST(Quantized, reference_0_quantize) {
   localCircularArenaAllocator<1024> meta_allocator;
@@ -24,11 +25,12 @@ TEST(Quantized, reference_0_quantize) {
   output_tensor->set_quantization_params(
       PerTensorQuantizationParams(zp, scale));
 
-  ::TFLM::QuantizeOperator<int8_t, float> op;
-  op.set_inputs({{TFLM::QuantizeOperator<int8_t, float>::input, input_tensor}})
-      .set_outputs(
-          {{TFLM::QuantizeOperator<int8_t, float>::output, output_tensor}})
-      .eval();
+  QuantizeOperator<int8_t, float> op;
+  op
+    .set_inputs({ { QuantizeOperator<int8_t, float>::input, input_tensor } })
+    .set_outputs({ { QuantizeOperator<int8_t, float>::output, output_tensor } })
+    .eval();
+  
   for (int i = 0; i < 784; ++i) {
     int8_t value = static_cast<int8_t>(output_tensor(i));
     EXPECT_EQ(value, ref_output_arr[i]);

--- a/TESTS/operators/test_quantized_dws_conv.cpp
+++ b/TESTS/operators/test_quantized_dws_conv.cpp
@@ -9,6 +9,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace TflmSymQuantOps;
 
 TEST(Quantized, reference_1_dws_conv) {
   localCircularArenaAllocator<1024> meta_allocator;

--- a/TESTS/operators/test_quantized_dws_conv.cpp
+++ b/TESTS/operators/test_quantized_dws_conv.cpp
@@ -44,16 +44,11 @@ TEST(Quantized, reference_1_dws_conv) {
   'DilationHFactor': 1}
   */
 
-  QuantizedDepthwiseSeparableConvOperator<int8_t> dw_conv_Aw(
-      {1, 1}, SAME, 32, {1, 1}, TFLM::TfLiteFusedActivation::kTfLiteActRelu);
+  DepthwiseSeparableConvOperator<int8_t> dw_conv_Aw({1,1}, SAME, 32, {1, 1}, TFLM::TfLiteFusedActivation::kTfLiteActRelu );
   dw_conv_Aw
-      .set_inputs(
-          {{QuantizedDepthwiseSeparableConvOperator<int8_t>::in, A},
-           {QuantizedDepthwiseSeparableConvOperator<int8_t>::filter, filter},
-           {QuantizedDepthwiseSeparableConvOperator<int8_t>::bias, bias}})
-      .set_outputs(
-          {{QuantizedDepthwiseSeparableConvOperator<int8_t>::out, out}})
-      .eval();
+    .set_inputs({ {DepthwiseSeparableConvOperator<int8_t>::in, A}, {DepthwiseSeparableConvOperator<int8_t>::filter, filter}, {DepthwiseSeparableConvOperator<int8_t>::bias, bias} })
+    .set_outputs({ {DepthwiseSeparableConvOperator<int8_t>::out, out} })
+    .eval();
 
   //  for(int i = 0; i < out->get_shape().get_linear_size(); i++) {
   // 21632

--- a/TESTS/operators/test_relu.cpp
+++ b/TESTS/operators/test_relu.cpp
@@ -14,6 +14,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 /*********************************************
  * Generated Test number

--- a/TESTS/operators/test_reshape.cpp
+++ b/TESTS/operators/test_reshape.cpp
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 
 using namespace uTensor;
-
+using namespace uTensor::ReferenceOperators;
 TEST(Reshape, reshape_test) {
   localCircularArenaAllocator<1024> meta_allocator;
   localCircularArenaAllocator<15 * 2 * sizeof(float), uint32_t> ram_allocator;
@@ -30,3 +30,4 @@ TEST(Reshape, reshape_test) {
   TensorShape output_shape = output_tensor->get_shape();
   EXPECT_TRUE(target_shape == output_shape);
 }
+

--- a/TESTS/operators/test_squeeze.cpp
+++ b/TESTS/operators/test_squeeze.cpp
@@ -9,6 +9,7 @@ using std::cout;
 using std::endl;
 
 using namespace uTensor;
+using namespace uTensor::ReferenceOperators;
 
 /*********************************************
  * Generated Test number

--- a/src/uTensor.h
+++ b/src/uTensor.h
@@ -36,4 +36,3 @@
  */
 #include "uTensor/errorHandlers/SimpleErrorHandler.hpp"
 
-using namespace uTensor::ReferenceOperators;

--- a/src/uTensor.h
+++ b/src/uTensor.h
@@ -35,3 +35,5 @@
  * Error Handlers
  */
 #include "uTensor/errorHandlers/SimpleErrorHandler.hpp"
+
+using namespace uTensor::ReferenceOperators;

--- a/src/uTensor/ops/ActivationFncs.hpp
+++ b/src/uTensor/ops/ActivationFncs.hpp
@@ -6,6 +6,7 @@
 #include "operatorBase.hpp"
 
 namespace uTensor {
+namespace ReferenceOperators {
 class InPlaceActivationFnc : public OperatorInterface<1, 0> {
  public:
   enum names_in : uint8_t { x };
@@ -82,6 +83,7 @@ class ReLU6Operator : public OperatorInterface<1, 1> {
   }
 };
 
+} 
 }  // namespace uTensor
 
 #endif

--- a/src/uTensor/ops/ArgMinMax.hpp
+++ b/src/uTensor/ops/ArgMinMax.hpp
@@ -4,7 +4,7 @@
 #include "ArgMinMax_kernel.hpp"
 
 namespace uTensor {
-
+namespace ReferenceOperators {
 template <typename Tin>
 class ArgMaxOperator : public OperatorInterface<2, 1>
 {
@@ -39,6 +39,7 @@ protected:
   }
 };
 
+}
 } // namespace uTensor
 
 #endif // UTENSOR_ARG_MIN_MAX_H

--- a/src/uTensor/ops/Arithmetic.hpp
+++ b/src/uTensor/ops/Arithmetic.hpp
@@ -7,6 +7,7 @@
 #include "operatorBase.hpp"
 
 namespace uTensor {
+namespace ReferenceOperators {
 
 template <typename T>
 class AddOperator : public OperatorInterface<2, 1> {
@@ -22,6 +23,6 @@ class AddOperator : public OperatorInterface<2, 1> {
   }
 };
 
-
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/Convolution.hpp
+++ b/src/uTensor/ops/Convolution.hpp
@@ -7,6 +7,7 @@
 #include "operatorBase.hpp"
 
 namespace uTensor {
+namespace ReferenceOperators {
 
 // Can use these intermediate types to make the convolution operator more
 // generic. Maxpool, conv, average pool, median etc. are all basically the same
@@ -199,5 +200,6 @@ using MaxPoolOperator = GenericPoolOperator<T, MaxFilter<T>>;
 template <typename T>
 using AvgPoolOperator = GenericPoolOperator<T, AvgFilter<T>>;
 
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/Dsp.hpp
+++ b/src/uTensor/ops/Dsp.hpp
@@ -6,6 +6,7 @@
 // https://github.com/ARM-software/ML-KWS-for-MCU/blob/master/Deployment/Source/MFCC/mfcc.h
 
 namespace uTensor {
+namespace ReferenceOperators {
 
 #define SAMP_FREQ 16000
 #define NUM_FBANK_BINS 40
@@ -152,6 +153,6 @@ void FixedMfccOperator<Tin, Tout>::populate_dct_matrix(
     }
   }
 }
-
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/Functional.hpp
+++ b/src/uTensor/ops/Functional.hpp
@@ -8,6 +8,7 @@
 #include "functional_kernels.hpp"
 #include "operatorBase.hpp"
 namespace uTensor {
+namespace ReferenceOperators {
 
 class InPlaceFnc : public OperatorInterface<1, 0> {
  public:
@@ -53,7 +54,7 @@ class SqueezeOperator : public InPlaceFnc {
  private:
   std::vector<uint8_t> _axis;
 };
-
+}
 }
 
 #endif

--- a/src/uTensor/ops/Matrix.hpp
+++ b/src/uTensor/ops/Matrix.hpp
@@ -6,6 +6,7 @@
 namespace uTensor {
 
 DECLARE_ERROR(InvalidMatrixMultIndicesError);
+namespace ReferenceOperators {
 
 // Assume c is already allocated to the correct size
 // Naive implementation
@@ -52,5 +53,6 @@ class MatrixMultOperator : public OperatorInterface<2, 1> {
   }
 };
 
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/Reshape.hpp
+++ b/src/uTensor/ops/Reshape.hpp
@@ -10,6 +10,7 @@
 using std::array;
 
 namespace uTensor {
+namespace ReferenceOperators {
 
 template <typename Tin>
 class ReshapeOperator : public OperatorInterface<1, 1> {
@@ -59,6 +60,7 @@ private:
   }
 };
 
+}
 }
 
 #endif // UTENSOR_RESHAPE_H

--- a/src/uTensor/ops/symmetric_quantization/QuantizeOps.hpp
+++ b/src/uTensor/ops/symmetric_quantization/QuantizeOps.hpp
@@ -8,7 +8,8 @@
 #include "operatorBase.hpp"
 
 namespace uTensor {
-namespace TFLM {
+namespace TflmSymQuantOps {
+
 // https://github.com/tensorflow/tensorflow/blob/fb4ec5cbde3973050e7350f0aca7f07ab7757bac/tensorflow/lite/kernels/internal/reference/dequantize.h#L30-L44
 template <typename OutputT, typename InputT>
 void dequantize_kernel(Tensor& b, const Tensor& a) {

--- a/src/uTensor/ops/symmetric_quantization/depthwise_separable_convolution.hpp
+++ b/src/uTensor/ops/symmetric_quantization/depthwise_separable_convolution.hpp
@@ -17,28 +17,28 @@ namespace TflmSymQuantOps {
 constexpr int kDepthwiseConvQuantizedDimension = 3;
 
 template <typename Tout>
-class QuantizedDepthwiseSeparableConvOperator : public OperatorInterface<3, 1> {
+class DepthwiseSeparableConvOperator : public OperatorInterface<3, 1> {
  public:
   enum names_in : uint8_t { in, filter, bias };
   enum names_out : uint8_t { out };
 
  public:
-  QuantizedDepthwiseSeparableConvOperator();
+  DepthwiseSeparableConvOperator();
   /*
-  QuantizedDepthwiseSeparableConvOperator(
+  DepthwiseSeparableConvOperator(
       const uint16_t (&strides)[2], Padding padding,
       const int depth_multiplier = 1, const uint16_t (&dialation)[2] = {1, 1});
-  QuantizedDepthwiseSeparableConvOperator(
+  DepthwiseSeparableConvOperator(
       const uint16_t (&strides)[4], Padding padding,
       const int depth_multiplier = 1, const uint16_t (&dialation)[2] = {1, 1});
   */
   // activation basically only used for TESTING, USE AT YOUR OWN RISK
-  QuantizedDepthwiseSeparableConvOperator(
+  DepthwiseSeparableConvOperator(
       const uint16_t (&strides)[2], Padding padding,
       const int depth_multiplier = 1, const uint16_t (&dialation)[2] = {1, 1},
       const TFLM::TfLiteFusedActivation activation = TFLM::kTfLiteActNone);
   //// activation basically only used for TESTING, USE AT YOUR OWN RISK
-  // QuantizedDepthwiseSeparableConvOperator(
+  // DepthwiseSeparableConvOperator(
   //    std::initializer_list<uint16_t> strides, Padding padding,
   //    const int depth_multiplier = 1, const uint16_t (&dialation)[2] = {1, 1},
   //    const TFLM::TfLiteFusedActivation activation = TFLM::kTfLiteActNone);
@@ -78,8 +78,8 @@ class QuantizedDepthwiseSeparableConvOperator : public OperatorInterface<3, 1> {
 };
 
 template <typename Tout>
-QuantizedDepthwiseSeparableConvOperator<
-    Tout>::QuantizedDepthwiseSeparableConvOperator()
+DepthwiseSeparableConvOperator<
+    Tout>::DepthwiseSeparableConvOperator()
     : _stride{1, 1, 1, 1},
       _padding(SAME),
       depth_multiplier(1),
@@ -92,8 +92,8 @@ QuantizedDepthwiseSeparableConvOperator<
       output_activation_max(std::numeric_limits<Tout>::max()) {}
 
 template <typename Tout>
-QuantizedDepthwiseSeparableConvOperator<Tout>::
-    QuantizedDepthwiseSeparableConvOperator(
+DepthwiseSeparableConvOperator<Tout>::
+    DepthwiseSeparableConvOperator(
         const uint16_t (&strides)[2], Padding padding,
         const int depth_multiplier, const uint16_t (&dialation)[2],
         TFLM::TfLiteFusedActivation activation)
@@ -104,7 +104,7 @@ QuantizedDepthwiseSeparableConvOperator<Tout>::
       activation(activation) {}
 
 template <typename Tout>
-void QuantizedDepthwiseSeparableConvOperator<Tout>::calculateOpData(
+void DepthwiseSeparableConvOperator<Tout>::calculateOpData(
     const Tensor& input, const Tensor& filter, const Tensor& bias,
     Tensor& output, const uint16_t (&strides)[4], const Padding padding,
     const uint16_t (&dialations)[2], int output_shift,
@@ -180,7 +180,7 @@ void QuantizedDepthwiseSeparableConvOperator<Tout>::calculateOpData(
 }
 
 template <typename Tout>
-void QuantizedDepthwiseSeparableConvOperator<Tout>::compute() {
+void DepthwiseSeparableConvOperator<Tout>::compute() {
   AllocatorInterface* ram_allocator =
       Context::get_default_context()->get_ram_data_allocator();
   const TensorShape& in_shape = inputs[in].tensor()->get_shape();

--- a/src/uTensor/ops/symmetric_quantization/depthwise_separable_convolution.hpp
+++ b/src/uTensor/ops/symmetric_quantization/depthwise_separable_convolution.hpp
@@ -10,13 +10,11 @@ namespace uTensor {
 DECLARE_ERROR(qDwsConvPerChannelMismatchError);
 DECLARE_ERROR(InvalidQuantizationSchemeError);
 
-namespace TFLM {
+namespace TflmSymQuantOps {
 
 // Keep this outside the Operator since we can include this file in the
 // Optimized Ops and get option data.
 constexpr int kDepthwiseConvQuantizedDimension = 3;
-
-}  // namespace TFLM
 
 template <typename Tout>
 class QuantizedDepthwiseSeparableConvOperator : public OperatorInterface<3, 1> {
@@ -132,7 +130,7 @@ void QuantizedDepthwiseSeparableConvOperator<Tout>::calculateOpData(
                                   &unused_output_height, &unused_output_width);
 
   int num_channels =
-      filter->get_shape()[TFLM::kDepthwiseConvQuantizedDimension];
+      filter->get_shape()[kDepthwiseConvQuantizedDimension];
   QuantizationParams affine_quantization = filter->get_quantization_params();
   const bool is_per_channel = affine_quantization.num_channels() > 1;
   // dws conv should be per channel quantized
@@ -207,7 +205,7 @@ void QuantizedDepthwiseSeparableConvOperator<Tout>::compute() {
 
   int num_channels = inputs[filter]
                          .tensor()
-                         ->get_shape()[TFLM::kDepthwiseConvQuantizedDimension];
+                         ->get_shape()[kDepthwiseConvQuantizedDimension];
   // Bind these params to a Handle so they dont accidentally get thrown away on
   // possible rebalance
   per_channel_output_multiplier = reinterpret_cast<int32_t*>(
@@ -260,5 +258,6 @@ void QuantizedDepthwiseSeparableConvOperator<Tout>::compute() {
   ram_allocator->deallocate(per_channel_output_multiplier);
 }
 
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/symmetric_quantization/fully_connected.hpp
+++ b/src/uTensor/ops/symmetric_quantization/fully_connected.hpp
@@ -7,6 +7,7 @@
 #include "symmetric_quantization_utils.hpp"
 
 namespace uTensor {
+namespace TflmSymQuantOps {
 
 template <typename T>
 class QuantizedMatrixMultiplyOperator : public OperatorInterface<3, 1> {};
@@ -78,5 +79,6 @@ class QuantizedMatrixMultiplyOperator<int8_t> : public OperatorInterface<3, 1> {
 template <typename Tout>
 using QuantizedFullyConnectedOperator = QuantizedMatrixMultiplyOperator<Tout>;
 
+}
 }  // namespace uTensor
 #endif

--- a/src/uTensor/ops/symmetric_quantization/fully_connected.hpp
+++ b/src/uTensor/ops/symmetric_quantization/fully_connected.hpp
@@ -77,7 +77,7 @@ class QuantizedMatrixMultiplyOperator<int8_t> : public OperatorInterface<3, 1> {
 };
 
 template <typename Tout>
-using QuantizedFullyConnectedOperator = QuantizedMatrixMultiplyOperator<Tout>;
+using FullyConnectedOperator = QuantizedMatrixMultiplyOperator<Tout>;
 
 }
 }  // namespace uTensor


### PR DESCRIPTION
I'm proposing is we try to keep 1) names of operators with same I/O patterns shared between namespaces, in other words ReferenceOperators::Conv2d and TFLM::Conv2d and CMSIS:Conv2d , 2) the same tensor enum I/O names in these ops (easy sauce), and 3) attempt to keep roughly the same order/names for input params, even if the types vary a bit. 4) framework specific input params are optional params and at the end of the function signature