### PR TITLE
Removed code pattern in the name of uTensor in Examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Follow instructions in the `README.md` in each tutorial directories to learn how
 
 Here are the links to the tutorials:
 
-1. [Error Handling with `uTensor`](tutorials/error_handling)
+1. [Error Handling with uTensor](tutorials/error_handling)
 2. [Custom Operator](tutorials/custom_operator)
 
 ## Introduction


### PR DESCRIPTION
Hi! 👋🏽 
I was going through the Readme and noticed there is a code pattern in the name of uTensor [here](https://github.com/uTensor/uTensor#building-tutorial-examples) like this : 
![Screenshot (39)](https://user-images.githubusercontent.com/64097541/104812752-60276f80-582a-11eb-9f2a-c129cc7ccd24.png)

So I made a small change to remove it.

Hope this PR gets merged soon! 🙂 

Thanks
Arijit (arijitdas18022006@gmail.com)