### PR TITLE
Add gtest xml output env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
           command: |
             cd build
             ctest -VV -o /tmp/test_results/test-results.txt
+          environment:
+            GTEST_OUTPUT: xml:/tmp/test_results/
 
       - run:
           name: Generate code coverage


### PR DESCRIPTION
This PR fixes xml output for ctest + gtest to fit nicely in the CircleCI workflow. Now it will display which tests pass/fail rather than forcing us to jump through the text