### PR TITLE
Bug fix: memory layout for conv2d_f Python API

### DIFF
--- a/python/cpp/impl/conv.cpp
+++ b/python/cpp/impl/conv.cpp
@@ -14,9 +14,9 @@ using namespace uTensor::ReferenceOperators::Conv2dConstants;
 static uTensor::localCircularArenaAllocator<32768, uint32_t> meta_allocator;
 static uTensor::localCircularArenaAllocator<32768, uint32_t> ram_allocator;
 
-py::array_t<float> conv2d_f(const py::array_t<float> &input,
-                            const py::array_t<float> &filter,
-                            const py::array_t<float> &bias,
+py::array_t<float> conv2d_f(const py::array_t<float, py::array::c_style> &input,
+                            const py::array_t<float, py::array::c_style> &filter,
+                            const py::array_t<float, py::array::c_style> &bias,
                             std::array<uint16_t, 4> strides,
                             std::string padding) {
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);

--- a/python/cpp/include/conv.hpp
+++ b/python/cpp/include/conv.hpp
@@ -9,8 +9,8 @@
 
 namespace py = pybind11;
 
-py::array_t<float> conv2d_f(const py::array_t<float> &input,
-                            const py::array_t<float> &filter,
-                            const py::array_t<float> &bias,
+py::array_t<float> conv2d_f(const py::array_t<float, py::array::c_style> &input,
+                            const py::array_t<float, py::array::c_style> &filter,
+                            const py::array_t<float, py::array::c_style> &bias,
                             std::array<uint16_t, 4> strides = {1, 1, 1, 1},
                             std::string padding = "VALID");


### PR DESCRIPTION
The current binding implementation assumes that the inputs are all c_style contiguous arrays, which is not always true.
The bug can be reproduced with examples like
```python
from python import _pyuTensor
import numpy as np
import tensorflow as tf
a_setting = (1, 5, 5, 3)
a = np.arange(np.prod(a_setting)).reshape(a_setting).astype(np.float32)
b_setting = (5, 5, 3, 5)
b = np.arange(np.prod(b_setting)).reshape(b_setting).astype(np.float32)

print(_pyuTensor.conv2d_f(a, b.transpose(3, 0, 1, 2), [0 for _ in range(b_setting[3])], [1, 2, 2, 1], "VALID"))
print(_pyuTensor.conv2d_f(a, b.transpose(3, 0, 1, 2).copy(), [0 for _ in range(b_setting[3])], [1, 2, 2, 1], "VALID"))
print(tf.nn.conv2d(a, b, strides=[1, 2, 2, 1], padding="VALID").numpy())
```
A temporary fix is just casting the arrays into c_style using pybind's constructor.