### PR TITLE
Fix signed integer overflow by casting to uint32_t

### DIFF
--- a/src/uTensor/allocators/arenaAllocator.hpp
+++ b/src/uTensor/allocators/arenaAllocator.hpp
@@ -13,7 +13,7 @@
 namespace uTensor {
 
 //#define MSB_SET ~( ~( (T)0 ) >> 1 )
-#define MSB_SET (1 << (sizeof(uint32_t) * 8 - 1))
+#define MSB_SET ((uint32_t)1 << (sizeof(uint32_t) * 8 - 1))
 #define BLOCK_INACTIVE ~MSB_SET
 #define BLOCK_LENGTH_MASK ~MSB_SET
 #define BLOCK_ACTIVE MSB_SET


### PR DESCRIPTION
Fixed an issue in arenaAllocator.hpp where left shifting 1 by more than the size of a signed integer caused undefined behavior due to signed integer overflow. The macro MSB_SET has been updated to cast 1 to uint32_t before performing the left shift, ensuring the operation is safe and defined.