### PR TITLE
Share memory view

### DIFF
--- a/TESTS/tensors/test_ramtensor.cpp
+++ b/TESTS/tensors/test_ramtensor.cpp
@@ -1,6 +1,6 @@
-#include "gtest/gtest.h"
 #include "uTensor.h"
 #include "uTensor/errorHandlers/SimpleErrorHandler.hpp"
+#include "gtest/gtest.h"
 
 #include <iostream>
 using std::cout;
@@ -10,7 +10,7 @@ using namespace uTensor;
 
 SimpleErrorHandler mErrHandler(10);
 
-void setup_context(){
+void setup_context() {
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -18,7 +18,7 @@ void setup_context(){
 }
 
 TEST(RAM_Tensor, constructor) {
-  //setup_context();
+  // setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -27,20 +27,20 @@ TEST(RAM_Tensor, constructor) {
 }
 
 TEST(RAM_Tensor, read_write_u8) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, u8);
-  r(2,2) = (uint8_t) 5;
-  uint8_t read = r(2,2);
+  r(2, 2) = (uint8_t)5;
+  uint8_t read = r(2, 2);
   EXPECT_EQ(read, 5);
   cout << "Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
 }
 
 TEST(RAM_Tensor, read_write_u8_multi_tensor) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<512> meta_allocator;
   localCircularArenaAllocator<512> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -48,85 +48,85 @@ TEST(RAM_Tensor, read_write_u8_multi_tensor) {
   RamTensor r1({10, 10}, u8);
   RamTensor r2({10, 10}, u8);
   RamTensor r3({10, 10}, u8);
-  r1(2,2) = (uint8_t) 5;
-  r2(2,2) = (uint8_t) 5;
-  r3(2,2) = (uint8_t) r1(2,2) + (uint8_t) r2(2,2);
-  EXPECT_EQ((uint8_t)r3(2,2), 10);
+  r1(2, 2) = (uint8_t)5;
+  r2(2, 2) = (uint8_t)5;
+  r3(2, 2) = (uint8_t)r1(2, 2) + (uint8_t)r2(2, 2);
+  EXPECT_EQ((uint8_t)r3(2, 2), 10);
   cout << "Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
 }
 
 TEST(RAM_Tensor, read_write_u8_2x) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, u8);
-  r(2,2) = (uint8_t) 5;
-  uint8_t read = r(2,2);
+  r(2, 2) = (uint8_t)5;
+  uint8_t read = r(2, 2);
   EXPECT_EQ(read, 5);
-  r(2,2) = (uint8_t) 15;
-  EXPECT_EQ((uint8_t)r(2,2), 15);
+  r(2, 2) = (uint8_t)15;
+  EXPECT_EQ((uint8_t)r(2, 2), 15);
 }
 
 TEST(RAM_Tensor, read_write_u8_contig) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, u8);
-  r(2,2) = (uint8_t) 5;
-  r(3,2) = (uint8_t) 35;
-  uint8_t read = r(2,2);
+  r(2, 2) = (uint8_t)5;
+  r(3, 2) = (uint8_t)35;
+  uint8_t read = r(2, 2);
   EXPECT_EQ(read, 5);
-  r(2,2) = (uint8_t) 15;
-  EXPECT_EQ((uint8_t)r(2,2), 15);
-  EXPECT_EQ((uint8_t)r(3,2), 35);
+  r(2, 2) = (uint8_t)15;
+  EXPECT_EQ((uint8_t)r(2, 2), 15);
+  EXPECT_EQ((uint8_t)r(3, 2), 35);
 }
 
 TEST(RAM_Tensor, read_write_i8) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, i8);
-  r(2,2) = (int8_t) -5;
-  int8_t read = r(2,2);
+  r(2, 2) = (int8_t)-5;
+  int8_t read = r(2, 2);
   EXPECT_EQ(read, -5);
   cout << "i8 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
   cout << "Sizeof RamTensor " << sizeof(r) << endl;
 }
 
 TEST(RAM_Tensor, read_write_u16) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, u16);
-  r(2,2) = (uint16_t) 5;
-  r(3,2) = (uint16_t) 15;
-  uint16_t read = r(2,2);
+  r(2, 2) = (uint16_t)5;
+  r(3, 2) = (uint16_t)15;
+  uint16_t read = r(2, 2);
   EXPECT_EQ(read, 5);
-  read = r(3,2);
+  read = r(3, 2);
   EXPECT_EQ(read, 15);
   cout << "uint16 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
 }
 
 TEST(RAM_Tensor, read_write_i16) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor r({10, 10}, i16);
-  r(2,2) = (int16_t) 5;
-  r(3,2) = (int16_t) -15;
-  int16_t read = r(2,2);
+  r(2, 2) = (int16_t)5;
+  r(3, 2) = (int16_t)-15;
+  int16_t read = r(2, 2);
   EXPECT_EQ(read, 5);
-  read = r(3,2);
+  read = r(3, 2);
   EXPECT_EQ(read, -15);
   cout << "uint16 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
 }
@@ -155,11 +155,11 @@ TEST(RAM_Tensor, resize_bigger_then_back) {
 
 TEST(RAM_Tensor, out_of_memory) {
   localCircularArenaAllocator<256> meta_allocator;
-  localCircularArenaAllocator<20*sizeof(float)> ram_allocator;
+  localCircularArenaAllocator<20 * sizeof(float)> ram_allocator;
   bool is_oom = false;
-  mErrHandler.set_onError([&is_oom](Error* err){
-    if(*err == OutOfMemError()) {
-      is_oom = true; 
+  mErrHandler.set_onError([&is_oom](Error *err) {
+    if (*err == OutOfMemError()) {
+      is_oom = true;
     }
   });
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -173,13 +173,32 @@ TEST(RAM_Tensor, out_of_memory) {
 
 TEST(RAM_Tensor, move_to_fit) {
   localCircularArenaAllocator<256> meta_allocator;
-  localCircularArenaAllocator<25*sizeof(float)> ram_allocator;
+  localCircularArenaAllocator<25 * sizeof(float)> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
   RamTensor a({5, 2}, flt);
   RamTensor b({2, 5}, flt);
-  const void* ori_ptr = b.get_address();
+  const void *ori_ptr = b.get_address();
   a.resize({5, 5});
-  const void* new_ptr = b.get_address();
+  const void *new_ptr = b.get_address();
   EXPECT_NE(ori_ptr, new_ptr);
+}
+
+TEST(RAM_Tensor, view) {
+  localCircularArenaAllocator<256> meta_allocator;
+  localCircularArenaAllocator<100 * sizeof(int32_t)> ram_allocator;
+  Context::get_default_context()->set_metadata_allocator(&meta_allocator);
+  Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
+  Tensor a = new RamTensor({10, 10}, i32);
+  for (int32_t i = 0; i < 100; i++) {
+    a(i) = i;
+  }
+  Tensor view = a.view({1, 8, 2}, {2, 10, 2});
+  int32_t read = view(0, 0);
+  EXPECT_EQ(read, 12);
+  read = view(2, 1);
+  EXPECT_EQ(read, 54);
+  a(12) = static_cast<int32_t>(100);
+  read = view(0, 0);
+  EXPECT_EQ(read, 100);
 }

--- a/TESTS/tensors/test_romtensor.cpp
+++ b/TESTS/tensors/test_romtensor.cpp
@@ -1,7 +1,5 @@
+#include "uTensor.h"
 #include "gtest/gtest.h"
-#include "arenaAllocator.hpp"
-#include "uTensor/core/context.hpp"
-#include "RomTensor.hpp"
 
 #include <iostream>
 using std::cout;
@@ -9,7 +7,7 @@ using std::endl;
 
 using namespace uTensor;
 
-void setup_context(){
+void setup_context() {
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
@@ -17,73 +15,73 @@ void setup_context(){
 }
 
 TEST(Rom_Tensor, constructor) {
-  //setup_context();
+  // setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  uint8_t* buffer = new uint8_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  uint8_t *buffer = new uint8_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, u8, buffer);
   delete[] buffer;
 }
 
 TEST(Rom_Tensor, fixed_constructor) {
-  //setup_context();
+  // setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  uint8_t buffer[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  uint8_t buffer[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, buffer);
 }
 
 TEST(Rom_Tensor, read_write_u8) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  uint8_t* buffer = new uint8_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  uint8_t *buffer = new uint8_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, u8, buffer);
-  uint8_t read = r(2,2);
+  uint8_t read = r(2, 2);
   EXPECT_EQ(read, 22);
   cout << "Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
   delete[] buffer;
 }
 
 TEST(Rom_Tensor, read_write_u8_2x) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  uint8_t* buffer = new uint8_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  uint8_t *buffer = new uint8_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, u8, buffer);
-  uint8_t read = r(2,2);
+  uint8_t read = r(2, 2);
   EXPECT_EQ(read, 22);
-  EXPECT_EQ((uint8_t)r(3,2), 32);
-  delete[]  buffer;
+  EXPECT_EQ((uint8_t)r(3, 2), 32);
+  delete[] buffer;
 }
 
 TEST(Rom_Tensor, read_write_i8) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  int8_t* buffer = new int8_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  int8_t *buffer = new int8_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, i8, buffer);
-  int8_t read = r(2,2);
+  int8_t read = r(2, 2);
   EXPECT_EQ(read, 22);
   cout << "i8 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
   cout << "Sizeof RomTensor " << sizeof(r) << endl;
@@ -91,37 +89,57 @@ TEST(Rom_Tensor, read_write_i8) {
 }
 
 TEST(Rom_Tensor, read_write_u16) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  uint16_t* buffer = new uint16_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  uint16_t *buffer = new uint16_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, u16, buffer);
-  uint16_t read = r(2,2);
+  uint16_t read = r(2, 2);
   EXPECT_EQ(read, 22);
-  read = r(3,2);
+  read = r(3, 2);
   EXPECT_EQ(read, 32);
   cout << "uint16 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
   delete[] buffer;
 }
 
 TEST(Rom_Tensor, read_write_i16) {
-  ///setup_context();
+  /// setup_context();
   localCircularArenaAllocator<256> meta_allocator;
   localCircularArenaAllocator<256> ram_allocator;
   Context::get_default_context()->set_metadata_allocator(&meta_allocator);
   Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
-  int16_t* buffer = new int16_t[10*10];
-  for(int i = 0; i < 100; i++)
-      buffer[i] = i;
+  int16_t *buffer = new int16_t[10 * 10];
+  for (int i = 0; i < 100; i++)
+    buffer[i] = i;
   const RomTensor r({10, 10}, i16, buffer);
-  int16_t read = r(2,2);
+  int16_t read = r(2, 2);
   EXPECT_EQ(read, 22);
-  read = r(3,2);
+  read = r(3, 2);
   EXPECT_EQ(read, 32);
   cout << "uint16 Sizeof IntegralValue " << sizeof(IntegralValue(5)) << endl;
   delete[] buffer;
+}
+
+TEST(Rom_Tensor, view) {
+  localCircularArenaAllocator<256> meta_allocator;
+  localCircularArenaAllocator<256> ram_allocator;
+  Context::get_default_context()->set_metadata_allocator(&meta_allocator);
+  Context::get_default_context()->set_ram_data_allocator(&ram_allocator);
+  int32_t buffer[100];
+  for (int32_t i = 0; i < 100; i++) {
+    buffer[i] = i;
+  }
+  Tensor a = new RomTensor({10, 10}, i32, buffer);
+  Tensor view = a.view({1, 8, 2}, {2, 10, 2});
+  int32_t read = view(0, 0);
+  EXPECT_EQ(read, 12);
+  read = view(2, 1);
+  EXPECT_EQ(read, 54);
+  a(12) = static_cast<int32_t>(100);
+  read = view(0, 0);
+  EXPECT_EQ(read, 100);
 }

--- a/src/uTensor/core/CMakeLists.txt
+++ b/src/uTensor/core/CMakeLists.txt
@@ -10,7 +10,7 @@ set(src_utensor_core
     errorHandler.cpp
     modelBase.cpp
     quantizationPrimitives.cpp
-   )
+)
 
 set(hdr_utensor_core
     types.hpp
@@ -25,8 +25,8 @@ set(hdr_utensor_core
     errorHandler.hpp
     modelBase.hpp
     quantizationPrimitives.hpp
-   )
-    
-add_library(utensor_core ${src_utensor_core} )
+)
+
+add_library(utensor_core ${src_utensor_core})
 target_include_directories(utensor_core PUBLIC .)
 target_compile_features(utensor_core PUBLIC cxx_std_11)

--- a/src/uTensor/core/tensor.cpp
+++ b/src/uTensor/core/tensor.cpp
@@ -7,46 +7,46 @@ namespace uTensor {
 // Tensor::Tensor(const Tensor& that) {} // Cannot copy Tensors, must pass by
 // reference
 
-TensorInterface* Tensor::operator->() {
-  return reinterpret_cast<TensorInterface*>(_ptr);
+TensorInterface *Tensor::operator->() {
+  return reinterpret_cast<TensorInterface *>(_ptr);
 }
-const TensorInterface* Tensor::operator->() const {
-  return reinterpret_cast<const TensorInterface*>(_ptr);
+const TensorInterface *Tensor::operator->() const {
+  return reinterpret_cast<const TensorInterface *>(_ptr);
 }
-TensorInterface* Tensor::operator*() {
-  return reinterpret_cast<TensorInterface*>(_ptr);
+TensorInterface *Tensor::operator*() {
+  return reinterpret_cast<TensorInterface *>(_ptr);
 }
 Tensor::~Tensor() { free(); }
 void Tensor::free() {
-  void* ptr_t = _ptr;  // unbind invalidates this handle so store a copy
+  void *ptr_t = _ptr; // unbind invalidates this handle so store a copy
   if (_ptr) {
-    AllocatorInterface* alloc =
+    AllocatorInterface *alloc =
         Context::get_default_context()->get_metadata_allocator();
     if (alloc->is_bound(_ptr, this)) {
       alloc->unbind(_ptr, this);
     }
-    delete reinterpret_cast<TensorInterface*>(ptr_t);
+    delete reinterpret_cast<TensorInterface *>(ptr_t);
     alloc->deallocate(ptr_t);
   }
   _ptr = nullptr;
 }
 Tensor::Tensor() : Handle() {}
-Tensor::Tensor(TensorInterface* ptr) : Handle((void*)ptr) {
+Tensor::Tensor(TensorInterface *ptr) : Handle((void *)ptr) {
   // Context::get_default_context()->get_metadata_allocator()->bind(_ptr, this);
   if (ptr != nullptr) {
     bind(*this, *Context::get_default_context()->get_metadata_allocator());
   }
 }
-Tensor& Tensor::operator=(TensorInterface* ptr) {
-  _ptr = (void*)ptr;
+Tensor &Tensor::operator=(TensorInterface *ptr) {
+  _ptr = (void *)ptr;
   bind(*this, *Context::get_default_context()->get_metadata_allocator());
   // Context::get_metadata_allocator()->bind(_ptr, this);
   return *this;
 }
 
-Tensor::Tensor(Tensor&& that) {
+Tensor::Tensor(Tensor &&that) {
   _ptr = that._ptr;
-  AllocatorInterface* alloc =
+  AllocatorInterface *alloc =
       Context::get_default_context()->get_metadata_allocator();
   if (alloc->is_bound(_ptr, &that)) {
     alloc->unbind(_ptr, &that);
@@ -54,10 +54,10 @@ Tensor::Tensor(Tensor&& that) {
   }
   that._ptr = nullptr;
 }
-Tensor& Tensor::operator=(Tensor&& that) {
+Tensor &Tensor::operator=(Tensor &&that) {
   if (this != &that) {
     _ptr = that._ptr;
-    AllocatorInterface* alloc =
+    AllocatorInterface *alloc =
         Context::get_default_context()->get_metadata_allocator();
     if (alloc->is_bound(_ptr, &that)) {
       alloc->unbind(_ptr, &that);
@@ -70,60 +70,60 @@ Tensor& Tensor::operator=(Tensor&& that) {
 // Add some bits to make the interface nicer to the user
 
 // Force everything to be on the utensor allocator
-void* Tensor::operator new(size_t sz) {  // Have to delegate this size from
-                                         // tensors somehow + sizeof(Tensor)
-  void* p =
+void *Tensor::operator new(size_t sz) { // Have to delegate this size from
+                                        // tensors somehow + sizeof(Tensor)
+  void *p =
       Context::get_default_context()->get_metadata_allocator()->allocate(sz);
   return p;
 }
-void Tensor::operator delete(void* p) {
+void Tensor::operator delete(void *p) {
   Context::get_default_context()->get_metadata_allocator()->deallocate(p);
 }
 
 // Interface
 const IntegralValue Tensor::operator()(uint16_t i, uint16_t j, uint16_t k,
                                        uint16_t l) const {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i, j, k, l);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i, j, k, l);
 }
 IntegralValue Tensor::operator()(uint16_t i, uint16_t j, uint16_t k,
                                  uint16_t l) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i, j, k, l);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i, j, k, l);
 }
 const IntegralValue Tensor::operator()(uint32_t linear_index) const {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(linear_index);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(linear_index);
 }
 IntegralValue Tensor::operator()(uint32_t linear_index) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(linear_index);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(linear_index);
 }
 
-TensorShape& Tensor::get_shape() {
-  return reinterpret_cast<TensorInterface*>(_ptr)->get_shape();
+TensorShape &Tensor::get_shape() {
+  return reinterpret_cast<TensorInterface *>(_ptr)->get_shape();
 }
 
-const TensorShape& Tensor::get_shape() const {
-  return reinterpret_cast<TensorInterface*>(_ptr)->get_shape();
+const TensorShape &Tensor::get_shape() const {
+  return reinterpret_cast<TensorInterface *>(_ptr)->get_shape();
 }
 
-TensorInterface* TensorReference::operator*() {
-  return reinterpret_cast<TensorInterface*>(_ref->operator*());
+TensorInterface *TensorReference::operator*() {
+  return reinterpret_cast<TensorInterface *>(_ref->operator*());
 }
 
 // Add a couple of bits for GDB debugging since GDB doesnt support operator()
 IntegralValue Tensor::gdb_read(uint16_t i) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i);
 }
 IntegralValue Tensor::gdb_read(uint16_t i, uint16_t j) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i, j);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i, j);
 }
 IntegralValue Tensor::gdb_read(uint16_t i, uint16_t j, uint16_t k) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i, j, k);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i, j, k);
 }
 IntegralValue Tensor::gdb_read(uint16_t i, uint16_t j, uint16_t k, uint16_t l) {
-  return reinterpret_cast<TensorInterface*>(_ptr)->operator()(i, j, k, l);
+  return reinterpret_cast<TensorInterface *>(_ptr)->operator()(i, j, k, l);
 }
 
-void print(const Tensor& t) {
-  const TensorShape& t_shape = t->get_shape();
+void print(const Tensor &t) {
+  const TensorShape &t_shape = t->get_shape();
   if (t_shape.num_dims() > 2) {
     uTensor_printf("printing > 2D tensors not supported\n");
     return;
@@ -133,30 +133,30 @@ void print(const Tensor& t) {
     uTensor_printf("[ ");
     for (int i = 0; i < t_shape[0]; i++) {
       switch (t->get_type()) {
-        case u8:
-          uTensor_printf("%hhu", static_cast<uint8_t>(t(j, i)));
-          break;
-        case i8:
-          uTensor_printf("%hhd", static_cast<int8_t>(t(j, i)));
-          break;
-        case u16:
-          uTensor_printf("%hu", static_cast<uint16_t>(t(j, i)));
-          break;
-        case i16:
-          uTensor_printf("%hd", static_cast<int16_t>(t(j, i)));
-          break;
-        case u32:
-          uTensor_printf("%u", static_cast<uint32_t>(t(j, i)));
-          break;
-        case i32:
-          uTensor_printf("%d", static_cast<int32_t>(t(j, i)));
-          break;
-        case flt:
-          uTensor_printf("%f", static_cast<float>(t(j, i)));
-          break;
-        default:
-          uTensor_printf("Unknown data type");
-          return;
+      case u8:
+        uTensor_printf("%hhu", static_cast<uint8_t>(t(j, i)));
+        break;
+      case i8:
+        uTensor_printf("%hhd", static_cast<int8_t>(t(j, i)));
+        break;
+      case u16:
+        uTensor_printf("%hu", static_cast<uint16_t>(t(j, i)));
+        break;
+      case i16:
+        uTensor_printf("%hd", static_cast<int16_t>(t(j, i)));
+        break;
+      case u32:
+        uTensor_printf("%u", static_cast<uint32_t>(t(j, i)));
+        break;
+      case i32:
+        uTensor_printf("%d", static_cast<int32_t>(t(j, i)));
+        break;
+      case flt:
+        uTensor_printf("%f", static_cast<float>(t(j, i)));
+        break;
+      default:
+        uTensor_printf("Unknown data type");
+        return;
       }
       if (i != (t_shape[0] - 1)) {
         uTensor_printf(", ");
@@ -169,10 +169,80 @@ void print(const Tensor& t) {
   uTensor_printf("]\n");
 }
 
-SimpleNamedTensor::SimpleNamedTensor(const uTensor::string& name,
-                                     Tensor& tensor)
+SimpleNamedTensor::SimpleNamedTensor(const uTensor::string &name,
+                                     Tensor &tensor)
     : name(&name), _tensor(&tensor) {}
 SimpleNamedTensor::SimpleNamedTensor() : name(nullptr), _tensor(nullptr) {}
-Tensor& SimpleNamedTensor::tensor() { return *_tensor; }
+Tensor &SimpleNamedTensor::tensor() { return *_tensor; }
 
-}  // namespace uTensor
+DEFINE_ERROR(ViewDoesNotSupportResizeError);
+
+Slice::Slice(int32_t start, int32_t end, int32_t step)
+    : start_(start), end_(end), step_(step) {}
+
+TensorView::TensorView(Tensor &other)
+    : base_(other), TensorInterface(other->get_shape(), other->get_type()) {}
+
+void TensorView::init_(int idx, const Slice &slice) {
+  _starts[idx] = slice.start();
+  _ends[idx] = slice.end();
+  _steps[idx] = slice.step();
+  _shape[idx] = (slice.end() - slice.start()) / slice.step() + 1;
+}
+
+TensorView::TensorView(Tensor &other, const Slice &slice1) : TensorView(other) {
+  init_(0, slice1);
+}
+
+TensorView::TensorView(Tensor &other, const Slice &slice1, const Slice &slice2)
+    : TensorView(other, slice1) {
+  init_(1, slice2);
+}
+
+TensorView::TensorView(Tensor &other, const Slice &slice1, const Slice &slice2,
+                       const Slice &slice3)
+    : TensorView(other, slice1, slice2) {
+  init_(2, slice3);
+}
+TensorView::TensorView(Tensor &other, const Slice &slice1, const Slice &slice2,
+                       const Slice &slice3, const Slice &slice4)
+    : TensorView(other, slice1, slice2, slice3) {
+  init_(3, slice4);
+}
+
+uint32_t TensorView::compute_linear_index(uint16_t i, uint16_t j, uint16_t k,
+                                          uint16_t l) const {
+  return base_->get_shape().linear_index(
+      i * _steps[0] + _starts[0], j * _steps[1] + _starts[1],
+      k * _steps[2] + _starts[2], l * _steps[3] + _starts[3]);
+}
+
+void *TensorView::read(uint32_t linear_index) const {
+  return base_->read(linear_index);
+}
+
+void *TensorView::write(uint32_t linear_index) {
+  return base_->write(linear_index);
+}
+
+void TensorView::resize(const TensorShape &new_shape) {
+  Context::get_default_context()->throwError(new ViewDoesNotSupportResizeError);
+}
+
+Tensor Tensor::view() { return Tensor(new TensorView(*this)); }
+Tensor Tensor::view(const Slice &slice1) {
+  return Tensor(new TensorView(*this, slice1));
+}
+Tensor Tensor::view(const Slice &slice1, const Slice &slice2) {
+  return Tensor(new TensorView(*this, slice1, slice2));
+}
+Tensor Tensor::view(const Slice &slice1, const Slice &slice2,
+                    const Slice &slice3) {
+  return Tensor(new TensorView(*this, slice1, slice2, slice3));
+}
+Tensor Tensor::view(const Slice &slice1, const Slice &slice2,
+                    const Slice &slice3, const Slice &slice4) {
+  return Tensor(new TensorView(*this, slice1, slice2, slice3, slice4));
+}
+
+} // namespace uTensor

--- a/src/uTensor/core/tensor.hpp
+++ b/src/uTensor/core/tensor.hpp
@@ -10,22 +10,29 @@ namespace uTensor {
 // move tensors around and delete them without affecting user code
 // template <typename Allocator=utensor::DefaultTensorMetaDataAllocator>
 //
-class alignas(alignof(uint8_t*)) Tensor : public Handle {
- public:
-  TensorInterface* operator->();
-  const TensorInterface* operator->() const;
+class Slice;
+class alignas(alignof(uint8_t *)) Tensor : public Handle {
+public:
+  TensorInterface *operator->();
+  const TensorInterface *operator->() const;
   // As long as operating on instantiations of this class and not pointers this
   // function will work
-  TensorInterface* operator*();
+  TensorInterface *operator*();
 
   Tensor();
-  Tensor(TensorInterface* ptr);
-  Tensor& operator=(TensorInterface* ptr);
-  Tensor(Tensor&& that);
-  Tensor& operator=(Tensor&& that);
+  Tensor(TensorInterface *ptr);
+  Tensor &operator=(TensorInterface *ptr);
+  Tensor(Tensor &&that);
+  Tensor &operator=(Tensor &&that);
   ~Tensor();
 
   void free();
+  Tensor view();
+  Tensor view(const Slice &slice1);
+  Tensor view(const Slice &slice1, const Slice &slice2);
+  Tensor view(const Slice &slice1, const Slice &slice2, const Slice &slice3);
+  Tensor view(const Slice &slice1, const Slice &slice2, const Slice &slice3,
+              const Slice &slice4);
 
   // Add some bits to make the interface nicer to the user
   const IntegralValue operator()(uint16_t i, uint16_t j, uint16_t k = 0,
@@ -35,12 +42,12 @@ class alignas(alignof(uint8_t*)) Tensor : public Handle {
   const IntegralValue operator()(uint32_t linear_index) const;
   IntegralValue operator()(uint32_t linear_index);
 
-  TensorShape& get_shape();
-  const TensorShape& get_shape() const;
+  TensorShape &get_shape();
+  const TensorShape &get_shape() const;
 
   // Force everything to be on the utensor allocator
-  void* operator new(size_t sz);
-  void operator delete(void* p);
+  void *operator new(size_t sz);
+  void operator delete(void *p);
 
   // KEY BIT
   friend class AllocatorInterface;
@@ -53,23 +60,66 @@ class alignas(alignof(uint8_t*)) Tensor : public Handle {
 };
 
 // Convenience
-void print(const Tensor& t);
+void print(const Tensor &t);
 
 class TensorReference : public HandleReference {
- public:
-  TensorInterface* operator*();
+public:
+  TensorInterface *operator*();
 };
 
 // Same as Named Tensor but not registered in the context class
 struct SimpleNamedTensor {
- public:
+public:
   SimpleNamedTensor();
-  SimpleNamedTensor(const uTensor::string& name, Tensor& tensor);
-  Tensor& tensor();
- public:
-  const uTensor::string* name;  // Fixed
- private:
-  Tensor* _tensor;               // Modifiable
+  SimpleNamedTensor(const uTensor::string &name, Tensor &tensor);
+  Tensor &tensor();
+
+public:
+  const uTensor::string *name; // Fixed
+private:
+  Tensor *_tensor; // Modifiable
 };
-}  // namespace uTensor
+
+DECLARE_ERROR(ViewDoesNotSupportResizeError);
+
+class Slice {
+public:
+  Slice(int32_t start, int32_t end, int32_t step = 1);
+
+  inline int32_t start() const { return start_; }
+  inline int32_t end() const { return end_; }
+  inline int32_t step() const { return step_; }
+
+private:
+  int32_t start_, end_, step_;
+};
+
+class TensorView : public TensorInterface {
+public:
+  // NOTE: currently only support positive slicing
+  // TODO: support negative indices and slicing
+  // TODO: reshape
+  TensorView(Tensor &other);
+  TensorView(Tensor &other, const Slice &slice1);
+  TensorView(Tensor &other, const Slice &slice1, const Slice &slice2);
+  TensorView(Tensor &other, const Slice &slice1, const Slice &slice2,
+             const Slice &slice3);
+  TensorView(Tensor &other, const Slice &slice1, const Slice &slice2,
+             const Slice &slice3, const Slice &slice4);
+
+protected:
+  virtual void *read(uint32_t linear_index) const override;
+  virtual void *write(uint32_t linear_index) override;
+  virtual void resize(const TensorShape &new_shape) override;
+  virtual uint32_t compute_linear_index(uint16_t i, uint16_t j, uint16_t k = 0,
+                                        uint16_t l = 0) const override;
+
+private:
+  Tensor &base_;
+  int32_t _starts[4];
+  int32_t _ends[4];
+  int32_t _steps[4];
+  void init_(int idx, const Slice &slice);
+};
+} // namespace uTensor
 #endif

--- a/src/uTensor/core/tensorBase.cpp
+++ b/src/uTensor/core/tensorBase.cpp
@@ -1,7 +1,7 @@
 #include "tensorBase.hpp"
 
-#include "uTensor/core/context.hpp"
 #include "memoryManagementInterface.hpp"
+#include "uTensor/core/context.hpp"
 #include "uTensor/core/uTensor_util.hpp"
 
 namespace uTensor {
@@ -16,48 +16,52 @@ TensorBase::~TensorBase() {
 }
 
 // Allocate the tensor metadata on a different heap from the data scratch pads
-void* TensorBase::operator new(size_t sz) {
-  void* p =
+void *TensorBase::operator new(size_t sz) {
+  void *p =
       Context::get_default_context()->get_metadata_allocator()->allocate(sz);
   return p;
 }
 
-void TensorBase::operator delete(void* p) {
-  if(p == nullptr){
+void TensorBase::operator delete(void *p) {
+  if (p == nullptr) {
     Context::get_default_context()->throwError(new NullTensorDeleteError);
   }
   Context::get_default_context()->get_metadata_allocator()->deallocate(p);
 }
 
 ttype TensorInterface::get_type() const { return _type; }
-TensorShape& TensorInterface::get_shape() { return _shape; }
-const TensorShape& TensorInterface::get_shape() const { return _shape; }
+TensorShape &TensorInterface::get_shape() { return _shape; }
+const TensorShape &TensorInterface::get_shape() const { return _shape; }
 uint32_t TensorInterface::num_elems() const { return _shape.num_elems(); }
 
 TensorInterface::TensorInterface()
-    : TensorBase(), _shape(0), _type(undefined), _type_size(0), _qnt_params(nullptr) {}
+    : TensorBase(), _shape(0), _type(undefined), _type_size(0),
+      _qnt_params(nullptr) {}
 TensorInterface::TensorInterface(ttype _type)
     : TensorBase(), _shape(0), _type(_type), _qnt_params(nullptr) {
   _type_size = type_size(_type);
 }
-TensorInterface::TensorInterface(const TensorShape& _shape, ttype _type)
+TensorInterface::TensorInterface(const TensorShape &_shape, ttype _type)
     : TensorBase(), _shape(_shape), _type(_type), _qnt_params(nullptr) {
   _type_size = type_size(_type);
 }
-TensorInterface::~TensorInterface(){
-};
+TensorInterface::~TensorInterface(){};
 
 // Can access Tensors like
 // mTensor(1) = 5, mTensor(2,2) = 5, etc.
+uint32_t TensorInterface::compute_linear_index(uint16_t i, uint16_t j,
+                                               uint16_t k, uint16_t l) const {
+  return _shape.linear_index(i, j, k, l);
+}
 const IntegralValue TensorInterface::operator()(uint16_t i, uint16_t j,
                                                 uint16_t k, uint16_t l) const {
   // Add shape checks here
-  return read(_shape.linear_index(i, j, k, l));
+  return read(compute_linear_index(i, j, k, l));
 }
 IntegralValue TensorInterface::operator()(uint16_t i, uint16_t j, uint16_t k,
                                           uint16_t l) {
   // Add shape checks here
-  return write(_shape.linear_index(i, j, k, l));
+  return write(compute_linear_index(i, j, k, l));
 }
 const IntegralValue TensorInterface::operator()(uint32_t linear_index) const {
   // Add shape checks here
@@ -68,11 +72,11 @@ IntegralValue TensorInterface::operator()(uint32_t linear_index) {
   return write(linear_index);
 }
 
-const QuantizationParams& TensorInterface::get_quantization_params() const {
+const QuantizationParams &TensorInterface::get_quantization_params() const {
   return *(_qnt_params.operator*());
 }
 
-size_t TensorInterface::_get_readable_block(const void*& buffer,
+size_t TensorInterface::_get_readable_block(const void *&buffer,
                                             uint16_t req_read_size,
                                             uint32_t linear_index) const {
   uTensor_printf(
@@ -81,7 +85,7 @@ size_t TensorInterface::_get_readable_block(const void*& buffer,
       new InvalidOptimizableTensorError());
   return -1;
 }
-size_t TensorInterface::_get_writeable_block(void*& buffer,
+size_t TensorInterface::_get_writeable_block(void *&buffer,
                                              uint16_t req_write_size,
                                              uint32_t linear_index) {
   uTensor_printf(
@@ -90,14 +94,15 @@ size_t TensorInterface::_get_writeable_block(void*& buffer,
       new InvalidOptimizableTensorError());
   return -1;
 }
-size_t TensorInterface::get_readable_block(const void*& buffer, uint16_t req_read_size,
+size_t TensorInterface::get_readable_block(const void *&buffer,
+                                           uint16_t req_read_size,
                                            uint32_t linear_index) const {
   if (req_read_size > _type_size * _shape.get_linear_size()) {
     return -1;
   }
   return _get_readable_block(buffer, req_read_size, linear_index);
 }
-size_t TensorInterface::get_writeable_block(void*& buffer,
+size_t TensorInterface::get_writeable_block(void *&buffer,
                                             uint16_t req_write_size,
                                             uint32_t linear_index) {
   if (req_write_size > _type_size * _shape.get_linear_size()) {
@@ -106,4 +111,4 @@ size_t TensorInterface::get_writeable_block(void*& buffer,
   return _get_writeable_block(buffer, req_write_size, linear_index);
 }
 
-}  // namespace uTensor
+} // namespace uTensor

--- a/src/uTensor/core/tensorBase.hpp
+++ b/src/uTensor/core/tensorBase.hpp
@@ -1,7 +1,7 @@
 #ifndef UTENSOR_TENSOR_BASE_H
 #define UTENSOR_TENSOR_BASE_H
-#include "quantizationPrimitives.hpp"
 #include "errorHandler.hpp"
+#include "quantizationPrimitives.hpp"
 #include "uTensor/core/types.hpp"
 
 namespace uTensor {
@@ -12,33 +12,38 @@ DECLARE_ERROR(NullTensorDeleteError);
  * into a known memory location in the Context class
  */
 class TensorBase {
- public:
+public:
   TensorBase();
   ~TensorBase();
 
   // Allocate the tensor metadata on a different heap from the data scratch pads
   // Note: as long as derived classes dont override new and delete, these will
   // get called correctly
-  void* operator new(size_t sz);
-  void operator delete(void* p);
+  void *operator new(size_t sz);
+  void operator delete(void *p);
 };
 
+class TensorView;
 // The public interface for all TensorMem types. This is the public contract for
 // users of tensors, handling basic data read/write, sizing, construction,
 // shaping, etc.
 class TensorInterface : public TensorBase {
   // DO not make these read/write calls public or Michael will smite you
- protected:
-  virtual void* read(uint32_t linear_index) const = 0;  // Handle to the data
-  virtual void* write(uint32_t linear_index) = 0;
+  friend class TensorView;
 
- public:
+protected:
+  virtual void *read(uint32_t linear_index) const = 0; // Handle to the data
+  virtual void *write(uint32_t linear_index) = 0;
+  virtual uint32_t compute_linear_index(uint16_t i, uint16_t j, uint16_t k = 0,
+                                        uint16_t l = 0) const;
+
+public:
   ttype get_type() const;
   uint32_t num_elems() const;
-  TensorShape& get_shape();
-  const TensorShape& get_shape() const;
+  TensorShape &get_shape();
+  const TensorShape &get_shape() const;
   TensorInterface();
-  TensorInterface(const TensorShape& _shape, ttype _type);
+  TensorInterface(const TensorShape &_shape, ttype _type);
   TensorInterface(ttype _type);
   virtual ~TensorInterface();
 
@@ -51,12 +56,12 @@ class TensorInterface : public TensorBase {
   const IntegralValue operator()(uint32_t linear_index) const;
   IntegralValue operator()(uint32_t linear_index);
 
-  virtual void resize(const TensorShape& new_shape) = 0;
-  template<typename QType>
-  TensorInterface& set_quantization_params(const QType& params);
-  const QuantizationParams& get_quantization_params() const;
+  virtual void resize(const TensorShape &new_shape) = 0;
+  template <typename QType>
+  TensorInterface &set_quantization_params(const QType &params);
+  const QuantizationParams &get_quantization_params() const;
 
- private:
+private:
   /** Optimized op interface
    * @param buffer pointer to data block to read from/write to in tensor managed
    * memory
@@ -65,37 +70,36 @@ class TensorInterface : public TensorBase {
    * @return the size of requested block, note may not be equal to the
    * req_read_size/write_size
    */
-  size_t get_readable_block(const void*& buffer, uint16_t req_read_size,
+  size_t get_readable_block(const void *&buffer, uint16_t req_read_size,
                             uint32_t linear_index) const;
-  size_t get_writeable_block(void*& buffer, uint16_t req_write_size,
+  size_t get_writeable_block(void *&buffer, uint16_t req_write_size,
                              uint32_t linear_index);
   friend class FastOperator;
 
- protected:
-  virtual size_t _get_readable_block(const void*& buffer, uint16_t req_read_size,
+protected:
+  virtual size_t _get_readable_block(const void *&buffer,
+                                     uint16_t req_read_size,
                                      uint32_t linear_index) const;
-  virtual size_t _get_writeable_block(void*& buffer, uint16_t req_write_size,
+  virtual size_t _get_writeable_block(void *&buffer, uint16_t req_write_size,
                                       uint32_t linear_index);
 
- protected:
+protected:
   TensorShape _shape;
-  ttype _type;  // Maybe make this const
+  ttype _type; // Maybe make this const
   uint8_t _type_size;
   QuantizationParamsHandle _qnt_params;
 };
-  
-template<typename QType>
-TensorInterface& TensorInterface::set_quantization_params(const QType& params){
-  if(!_qnt_params){
+
+template <typename QType>
+TensorInterface &TensorInterface::set_quantization_params(const QType &params) {
+  if (!_qnt_params) {
     _qnt_params = new QType(params);
-  }
-  else {
-   // _qnt_params = params;
-   // ERROR
+  } else {
+    // _qnt_params = params;
+    // ERROR
   }
   return *this;
-
 }
 
-}  // namespace uTensor
+} // namespace uTensor
 #endif


### PR DESCRIPTION
I implement the share memory view for `uTensor::Tensor`.
Currently it only support slicing.
Will implement reshape view later.

The API:
```cpp
Tensor a = new RamTensor({10, 10}, flt);
// conceptually the same as a[1:8:2, 2:10:2] in Python (Numpy).
Tensor view = a.view({1, 8, 2}, {2, 10, 2});
float read = view(0, 0); // which is the same as `a(12)`
// update to `a` is visible to `view`
a(12) = static_cast<float>(100.0);
read = view(0, 0); // 100.0
```